### PR TITLE
Add message listener registration to RtcSession

### DIFF
--- a/store.ts
+++ b/store.ts
@@ -25,8 +25,8 @@ export function useRtcAndMesh() {
         push('rx:non-json');
       }
     };
-    (rtc as any).events.onMessage = onMsg; // bind
-    return () => { (rtc as any).events.onMessage = undefined; };
+    const off = rtc.onMessage(onMsg);
+    return off;
   }, [mesh, rtc]);
 
   function createOffer(){


### PR DESCRIPTION
## Summary
- add `onMessage` helper to `RtcSession` for managing message listeners
- use new `onMessage` API in store to register mesh message handler without casts

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b62b07008321afba02038113b82d