### PR TITLE
Add RTC session cleanup effect

### DIFF
--- a/store.ts
+++ b/store.ts
@@ -11,6 +11,13 @@ export function useRtcAndMesh() {
   const [log, setLog] = useState<string[]>([]);
 
   const rtc = useMemo(() => new RtcSession({ useStun, onOpen: ()=>push('dc-open'), onClose: r=>push('dc-close:'+r), onError: e=>push('dc-error:'+e), onState: s=>push(`ice:${s.ice}`) }), [useStun]);
+
+  useEffect(() => {
+    return () => {
+      rtc.close();
+    };
+  }, [rtc]);
+
   const mesh = useMemo(() => new MeshRouter(crypto.randomUUID()), []);
 
   function push(s:string){ setLog((l)=>[s, ...l].slice(0,200)); }


### PR DESCRIPTION
## Summary
- ensure `useRtcAndMesh` closes RTC sessions when re-created or unmounted via a cleanup `useEffect`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a8f07f00832194244c4c193a3cc1