### PR TITLE
Handle send errors in Chat

### DIFF
--- a/Chat.tsx
+++ b/Chat.tsx
@@ -7,8 +7,12 @@ export default function Chat(){
 
   async function send(){
     if (!text.trim()) { alert('Enter a message'); return; }
-    sendMesh({ text });
-    setText('');
+    try {
+      sendMesh({ text });
+      setText('');
+    } catch (err) {
+      alert(err instanceof Error ? err.message : String(err));
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- prevent uncaught exceptions when sending chat messages by wrapping `sendMesh` in a try/catch and alerting on errors

## Testing
- `npm install` *(fails: Not Found - GET https://registry.npmjs.org/@types%2fjsqr)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a8f5056c8321b96d6135df44c63f