### PR TITLE
Add VoiceClient disposal and cleanup in VoicePanel

### DIFF
--- a/VoicePanel.tsx
+++ b/VoicePanel.tsx
@@ -2,22 +2,21 @@ import { useEffect, useRef, useState } from 'react';
 import { VoiceClient } from './voice_index';
 
 export default function VoicePanel(){
-  const clientRef = useRef<VoiceClient>();
+  const clientRef = useRef<VoiceClient | null>(null);
   const [status, setStatus] = useState('idle');
   const [modelPath, setModelPath] = useState('/models/ggml-base.en.bin');
   const [partials, setPartials] = useState<string[]>([]);
   const [finals, setFinals] = useState<string[]>([]);
 
   useEffect(()=>{
-    const c = new VoiceClient();
-    const off = c.on((e)=>{
+    clientRef.current = new VoiceClient();
+    const off = clientRef.current.on((e)=>{
       if(e.type==='status') setStatus(e.status);
       if(e.type==='partial') setPartials(p=>[e.text, ...p].slice(0,50));
       if(e.type==='final') setFinals(p=>[e.text, ...p].slice(0,200));
       if(e.type==='error') alert(e.error);
     });
-    clientRef.current = c;
-    return () => { off(); };
+    return () => { clientRef.current?.dispose(); off(); };
   },[]);
 
   async function init(){ clientRef.current?.post({ type:'init', modelPath }); }

--- a/voice_index.ts
+++ b/voice_index.ts
@@ -24,4 +24,9 @@ export class VoiceClient {
 
   on(fn: (e: VoiceWorkerEvt) => void) { this.listeners.add(fn); return () => this.listeners.delete(fn); }
   post(cmd: VoiceWorkerCmd) { this.worker.postMessage(cmd); }
+
+  dispose() {
+    this.worker.terminate();
+    this.listeners.clear();
+  }
 }


### PR DESCRIPTION
## Summary
- add dispose method to VoiceClient to terminate its worker and clear listeners
- persist VoiceClient in a ref and dispose it during VoicePanel cleanup

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run check` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68b3a8f846e483219100106c8ac367c2