### PR TITLE
Add AES-GCM encryption helpers

### DIFF
--- a/envelope.test.ts
+++ b/envelope.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { generateKeyPair, deriveAesKey, encrypt, decrypt } from './envelope';
+
+describe('envelope', () => {
+  it('encrypts and decrypts round-trip', async () => {
+    const alice = await generateKeyPair();
+    const bob = await generateKeyPair();
+    const aliceKey = await deriveAesKey(bob.publicKey, alice.privateKey);
+    const bobKey = await deriveAesKey(alice.publicKey, bob.privateKey);
+    const msg = 'secret message';
+    const cipher = await encrypt(msg, aliceKey);
+    const clear = await decrypt(cipher, bobKey);
+    expect(clear).toBe(msg);
+  });
+});

--- a/envelope.ts
+++ b/envelope.ts
@@ -11,4 +11,47 @@ export async function generateKeyPair(): Promise<KeyPair> {
 export async function exportPublicKeyJwk(key: CryptoKey): Promise<JsonWebKey> {
   return crypto.subtle.exportKey('jwk', key);
 }
-// TODO: add AES-GCM envelope in v0.1
+
+export async function deriveAesKey(
+  peerPublicKey: CryptoKey,
+  myPrivateKey: CryptoKey
+): Promise<CryptoKey> {
+  return crypto.subtle.deriveKey(
+    { name: 'ECDH', public: peerPublicKey },
+    myPrivateKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+export async function encrypt(
+  message: string,
+  key: CryptoKey
+): Promise<Uint8Array> {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const encoded = new TextEncoder().encode(message);
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    encoded
+  );
+  const buf = new Uint8Array(iv.byteLength + ciphertext.byteLength);
+  buf.set(iv, 0);
+  buf.set(new Uint8Array(ciphertext), iv.byteLength);
+  return buf;
+}
+
+export async function decrypt(
+  ciphertext: Uint8Array,
+  key: CryptoKey
+): Promise<string> {
+  const iv = ciphertext.slice(0, 12);
+  const data = ciphertext.slice(12);
+  const plain = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    data
+  );
+  return new TextDecoder().decode(plain);
+}


### PR DESCRIPTION
## Summary
- implement ECDH-based AES key derivation and AES-GCM encrypt/decrypt utilities
- add round-trip test for envelope helpers

## Testing
- `npm install` *(fails: '@types/jsqr@^1.3.2' is not in this registry)*
- `npx -y vitest run` *(fails: Cannot find package 'vitest' imported from vitest.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a8fe4db883218dc77bd312daf37c