### PR TITLE
Check cache responses and clean old caches in sw

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,15 +1,23 @@
 // Very small network-first SW that caches same-origin GET responses.
 const CACHE = 'svm-cache-v1';
 self.addEventListener('install', (e) => { self.skipWaiting(); });
-self.addEventListener('activate', (e) => { e.waitUntil(clients.claim()); });
+self.addEventListener('activate', (e) => {
+  e.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(keys.filter((key) => key !== CACHE).map((key) => caches.delete(key)));
+    await clients.claim();
+  })());
+});
 self.addEventListener('fetch', (e) => {
   const req = e.request;
   if (req.method !== 'GET' || new URL(req.url).origin !== location.origin) return;
   e.respondWith((async () => {
     try {
       const res = await fetch(req);
-      const cache = await caches.open(CACHE);
-      cache.put(req, res.clone());
+      if (res.ok) {
+        const cache = await caches.open(CACHE);
+        await cache.put(req, res.clone());
+      }
       return res;
     } catch (err) {
       const cache = await caches.open(CACHE);


### PR DESCRIPTION
## Summary
- cache network responses only when OK to avoid storing errors
- delete outdated caches during service worker activation

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a901d52c83218164d60f6fd7cd73