### PR TITLE
Add aria labels to chat controls and QR canvases

### DIFF
--- a/Chat.tsx
+++ b/Chat.tsx
@@ -15,8 +15,8 @@ export default function Chat(){
     <div className="card">
       <h2>Chat</h2>
       <div className="row">
-        <input value={text} onChange={e=>setText(e.target.value)} placeholder="Message" />
-        <button onClick={send} title="Send message over DataChannel">Send</button>
+        <input value={text} onChange={e=>setText(e.target.value)} placeholder="Message" aria-label="Message input" />
+        <button onClick={send} title="Send message over DataChannel" aria-label="Send message">Send</button>
       </div>
       <div style={{marginTop:12}}>
         <div className="small">Last incoming:</div>

--- a/QRPairing.tsx
+++ b/QRPairing.tsx
@@ -52,7 +52,7 @@ export default function QRPairing(){
           <button onClick={beginOffer} title="Create an SDP offer and render as QR">Create Offer</button>
           <button onClick={()=> navigator.clipboard.writeText(offerJson)} aria-disabled={!offerJson} title={offerJson? 'Copy offer JSON' : 'Create an offer first'}>Copy Offer</button>
         </div>
-        <canvas ref={offerCanvasRef} style={{marginTop:12}}/>
+        <canvas ref={offerCanvasRef} style={{marginTop:12}} aria-label="Offer QR code"/>
         <p className="small">Offer JSON length: {offerJson.length}</p>
 
         <h3>Paste Remote Answer</h3>
@@ -69,7 +69,7 @@ export default function QRPairing(){
           <button onClick={scanAndAcceptOffer} title="Scan offer QR from Device A">Scan Offer QR</button>
           <button onClick={()=> navigator.clipboard.writeText(answerJson)} aria-disabled={!answerJson} title={answerJson? 'Copy answer JSON' : 'Scan or paste an offer first'}>Copy Answer</button>
         </div>
-        <canvas ref={answerCanvasRef} style={{marginTop:12}}/>
+        <canvas ref={answerCanvasRef} style={{marginTop:12}} aria-label="Answer QR code"/>
         <p className="small">Answer JSON length: {answerJson.length}</p>
       </div>
 


### PR DESCRIPTION
## Summary
- add aria-labels for chat input and send button
- add descriptive aria-labels for offer and answer QR canvases

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run check` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68b3d1ab9fec8321b6570bbcf755ff36