### PR TITLE
feat: precache model assets in service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,18 +1,33 @@
 // Very small network-first SW that caches same-origin GET responses.
 const CACHE = 'svm-cache-v1';
-self.addEventListener('install', (e) => { self.skipWaiting(); });
+// Pre-cache model assets so voice recognition works offline.
+const PRECACHE = [
+  '/models/ggml-base.en.bin',
+];
+self.addEventListener('install', (e) => {
+  e.waitUntil((async () => {
+    const cache = await caches.open(CACHE);
+    await cache.addAll(PRECACHE);
+  })());
+  self.skipWaiting();
+});
 self.addEventListener('activate', (e) => { e.waitUntil(clients.claim()); });
 self.addEventListener('fetch', (e) => {
   const req = e.request;
-  if (req.method !== 'GET' || new URL(req.url).origin !== location.origin) return;
+  const url = new URL(req.url);
+  if (req.method !== 'GET' || url.origin !== location.origin) return;
   e.respondWith((async () => {
+    const cache = await caches.open(CACHE);
+    // Serve pre-cached model assets directly from cache.
+    if (PRECACHE.includes(url.pathname)) {
+      const hit = await cache.match(req);
+      if (hit) return hit;
+    }
     try {
       const res = await fetch(req);
-      const cache = await caches.open(CACHE);
       cache.put(req, res.clone());
       return res;
     } catch (err) {
-      const cache = await caches.open(CACHE);
       const hit = await cache.match(req);
       if (hit) return hit;
       throw err;


### PR DESCRIPTION
## Summary
- cache `/models/ggml-base.en.bin` during service worker install
- serve cached model assets when offline

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: @types/jsqr not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d1c0ef748321a8f399fdec5b54cc