### PR TITLE
Configure Netlify deploy previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,6 @@ npm run build
 
 ## Netlify
 Uses `netlify.toml` to run `npm run build` and publish `dist`.
+
+Pull requests receive Netlify Deploy Previews at URLs like:
+`https://deploy-preview-<PR_NUMBER>--<SITE_NAME>.netlify.app`

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,10 @@
   command = "npm run build"
   publish = "dist"
 
+[context.deploy-preview]
+  command = "npm run build"
+  publish = "dist"
+
 [dev]
   command = "vite"
   port = 5173


### PR DESCRIPTION
## Summary
- run build for Netlify deploy previews
- document Netlify preview URLs in README

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run check` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68b3d1cc1f3483218439c567b5879e16