### PR TITLE
feat: abstract mesh router for pluggable transports

### DIFF
--- a/Mesh.ts
+++ b/Mesh.ts
@@ -1,32 +1,160 @@
 export type Message = { id: string; ttl: number; from: string; type: string; payload: any };
 
+/** Interface for a transport used by MeshRouter. */
+export interface MeshBackend {
+  send(msg: Message): void;
+  close(): void;
+  onmessage?: (msg: Message) => void;
+  onclose?: () => void;
+}
+
 /**
- * Simple in-memory mesh relay with TTL and dedupe.
+ * MeshRouter routes messages between peers using pluggable transports.
+ * It handles TTL, de-duplication and automatic reconnection of transports
+ * when network partitions occur.
  */
 export class MeshRouter {
-  private peers: Map<string, (msg: Message) => void> = new Map();
+  private peers: Map<string, MeshBackend> = new Map();
+  private factories: Map<string, () => MeshBackend> = new Map();
   private seen: Set<string> = new Set();
-  constructor(public readonly selfId: string) {}
+  constructor(
+    public readonly selfId: string,
+    private readonly reconnectBaseMs: number = 50,
+    private readonly reconnectMaxMs: number = 10_000,
+  ) {}
 
-  connectPeer(id: string, handler: (msg: Message) => void) { this.peers.set(id, handler); }
-  disconnectPeer(id: string) { this.peers.delete(id); }
+  /**
+   * Connect to a peer using the provided factory. When the underlying
+   * transport closes the router will attempt to reconnect with an
+   * exponential backoff.
+   */
+  connectPeer(id: string, factory: () => MeshBackend) {
+    this.factories.set(id, factory);
+    this.openPeer(id, 0);
+  }
 
+  /** Disconnect from a peer and stop reconnect attempts. */
+  disconnectPeer(id: string) {
+    this.factories.delete(id);
+    const peer = this.peers.get(id);
+    peer?.close();
+    this.peers.delete(id);
+  }
+
+  /** Send a message originating from this router. */
   send(msg: Omit<Message, 'from'>) {
     const full: Message = { ...msg, from: this.selfId };
     this.deliver(full);
   }
 
+  /** Incoming message from an external transport. */
+  ingress(msg: Message) {
+    this.deliver(msg);
+  }
+
+  private openPeer(id: string, attempt: number) {
+    const factory = this.factories.get(id);
+    if (!factory) return;
+    const backend = factory();
+    backend.onmessage = (m) => this.ingress(m);
+    backend.onclose = () => {
+      this.peers.delete(id);
+      const delay = Math.min(this.reconnectBaseMs * 2 ** attempt, this.reconnectMaxMs);
+      setTimeout(() => this.openPeer(id, attempt + 1), delay);
+    };
+    this.peers.set(id, backend);
+  }
+
   private deliver(msg: Message) {
     if (this.seen.has(msg.id)) return;
     this.seen.add(msg.id);
-    for (const [id, h] of this.peers) {
-      if (id === msg.from) continue; // no immediate echo back to sender id
+    for (const [id, peer] of this.peers) {
+      if (id === msg.from) continue; // no echo to sender
       if (msg.ttl <= 0) continue;
       const forwarded: Message = { ...msg, ttl: msg.ttl - 1 };
-      queueMicrotask(() => h(forwarded));
+      queueMicrotask(() => peer.send(forwarded));
+    }
+  }
+}
+
+/** WebSocket backend implementation */
+export class WebSocketBackend implements MeshBackend {
+  private ws: WebSocket;
+  onmessage?: (msg: Message) => void;
+  onclose?: () => void;
+
+  constructor(private url: string) {
+    this.ws = this.createSocket();
+  }
+
+  private createSocket(): WebSocket {
+    const ws = new WebSocket(this.url);
+    ws.onmessage = (ev) => {
+      try {
+        const msg: Message = JSON.parse(ev.data as any);
+        this.onmessage?.(msg);
+      } catch {
+        /* ignore */
+      }
+    };
+    ws.onclose = () => this.onclose?.();
+    return ws;
+  }
+
+  send(msg: Message) {
+    if (this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(msg));
     }
   }
 
-  // external ingress from RTC: call this when a remote peer delivers a message
-  ingress(msg: Message) { this.deliver(msg); }
+  close() {
+    this.ws.close();
+  }
+}
+
+/** WebTransport backend implementation (minimal) */
+export class WebTransportBackend implements MeshBackend {
+  private transport: any;
+  private writer?: any;
+  onmessage?: (msg: Message) => void;
+  onclose?: () => void;
+
+  constructor(private url: string) {
+    this.open();
+  }
+
+  private async open() {
+    try {
+      const WT = (globalThis as any).WebTransport;
+      if (!WT) throw new Error('WebTransport unavailable');
+      this.transport = new WT(this.url);
+      const reader = this.transport.datagrams.readable.getReader();
+      this.writer = this.transport.datagrams.writable.getWriter();
+      const dec = new TextDecoder();
+      (async () => {
+        try {
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            this.onmessage?.(JSON.parse(dec.decode(value)));
+          }
+        } catch {
+          /* ignore */
+        }
+        this.onclose?.();
+      })();
+    } catch {
+      this.onclose?.();
+    }
+  }
+
+  send(msg: Message) {
+    if (!this.writer) return;
+    const enc = new TextEncoder().encode(JSON.stringify(msg));
+    this.writer.write(enc);
+  }
+
+  close() {
+    try { this.transport.close(); } catch {}
+  }
 }

--- a/mesh.test.ts
+++ b/mesh.test.ts
@@ -1,5 +1,21 @@
 import { describe, it, expect } from 'vitest';
-import { MeshRouter, Message } from './Mesh';
+import { MeshRouter, Message, MeshBackend } from './Mesh';
+
+// helper to create in-memory backends that link two routers
+function link(a: MeshRouter, b: MeshRouter) {
+  a.connectPeer(b.selfId, () => ({
+    send: (m: Message) => b.ingress(m),
+    close: () => {},
+  }));
+}
+
+// helper backend for inbox capturing
+function inboxBackend(arr: Message[]): () => MeshBackend {
+  return () => ({
+    send: (m: Message) => arr.push(m),
+    close: () => {},
+  });
+}
 
 describe('MeshRouter', () => {
   it('honors TTL and dedupes', async () => {
@@ -9,24 +25,71 @@ describe('MeshRouter', () => {
 
     const inboxC: Message[] = [];
 
-    a.connectPeer('B', (m)=> b.ingress(m));
-    b.connectPeer('A', (m)=> a.ingress(m));
-    b.connectPeer('C', (m)=> c.ingress(m));
-    c.connectPeer('B', (m)=> b.ingress(m));
+    link(a, b);
+    link(b, a);
+    link(b, c);
+    link(c, b);
 
-    c.connectPeer('A', (m)=> a.ingress(m)); // extra edge
-    c.connectPeer('INBOX', (m)=> inboxC.push(m));
+    // extra edge
+    link(c, a);
+
+    c.connectPeer('INBOX', inboxBackend(inboxC));
 
     a.send({ id: 'x', ttl: 2, type: 'chat', payload: 'hi' } as any);
-    await new Promise(r=>setTimeout(r, 10));
+    await new Promise((r) => setTimeout(r, 10));
 
     expect(inboxC.length).toBeGreaterThan(0);
-    const ids = new Set(inboxC.map(m => m.id));
+    const ids = new Set(inboxC.map((m) => m.id));
     expect(ids.size).toBe(inboxC.length);
 
     inboxC.length = 0;
     a.send({ id: 'y', ttl: 0, type: 'chat', payload: 'nope' } as any);
-    await new Promise(r=>setTimeout(r, 10));
+    await new Promise((r) => setTimeout(r, 10));
     expect(inboxC.length).toBe(0);
   });
+
+  it('reconnects after network partition', async () => {
+    const a = new MeshRouter('A', 5, 20); // fast reconnect for tests
+    const b = new MeshRouter('B', 5, 20);
+    const inboxB: Message[] = [];
+
+    let currentAtoB: FlakyBackend | null = null;
+    const factoryA = () => (currentAtoB = new FlakyBackend(b));
+
+    a.connectPeer('B', factoryA);
+    b.connectPeer('INBOX', inboxBackend(inboxB));
+
+    // initial message works
+    a.send({ id: '1', ttl: 2, type: 'chat', payload: 'hi' } as any);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(inboxB.length).toBe(1);
+
+    // simulate partition
+    currentAtoB!.simulateClose();
+
+    inboxB.length = 0;
+    a.send({ id: '2', ttl: 2, type: 'chat', payload: 'lost' } as any);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(inboxB.length).toBe(0); // not delivered while partitioned
+
+    // wait for reconnection
+    await new Promise((r) => setTimeout(r, 50));
+
+    a.send({ id: '3', ttl: 2, type: 'chat', payload: 'again' } as any);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(inboxB.length).toBe(1);
+  });
 });
+
+class FlakyBackend implements MeshBackend {
+  onmessage?: (msg: Message) => void;
+  onclose?: () => void;
+  constructor(private target: MeshRouter) {}
+  send(msg: Message) {
+    this.target.ingress(msg);
+  }
+  close() {}
+  simulateClose() {
+    this.onclose?.();
+  }
+}


### PR DESCRIPTION
## Summary
- refactor MeshRouter to use pluggable backends with automatic reconnection
- add WebSocket and WebTransport transport implementations
- expand tests to cover reconnection logic

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: '@types/jsqr@^1.3.2' not in npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d1d6685483219a80078c8369a92c