### PR TITLE
feat: manage multiple RTC sessions and selective peer chat

### DIFF
--- a/Chat.tsx
+++ b/Chat.tsx
@@ -1,26 +1,41 @@
 import { useRtcAndMesh } from './store';
 import { useState } from 'react';
 
-export default function Chat(){
-  const { sendMesh, lastMsg } = useRtcAndMesh();
+export default function Chat() {
+  const { sendMesh, lastMsg, peers } = useRtcAndMesh();
   const [text, setText] = useState('');
+  const [target, setTarget] = useState('');
 
-  async function send(){
-    if (!text.trim()) { alert('Enter a message'); return; }
-    sendMesh({ text });
+  async function send() {
+    if (!text.trim()) {
+      alert('Enter a message');
+      return;
+    }
+    const targets = target ? [target] : undefined;
+    sendMesh({ text }, targets);
     setText('');
   }
 
   return (
     <div className="card">
       <h2>Chat</h2>
-      <div className="row">
-        <input value={text} onChange={e=>setText(e.target.value)} placeholder="Message" />
+      <div className="row" style={{ gap: 8 }}>
+        <select value={target} onChange={e => setTarget(e.target.value)} title="Select peer to send to">
+          <option value="">All Peers</option>
+          {peers.map(p => (
+            <option key={p} value={p}>{p}</option>
+          ))}
+        </select>
+        <input value={text} onChange={e => setText(e.target.value)} placeholder="Message" />
         <button onClick={send} title="Send message over DataChannel">Send</button>
       </div>
-      <div style={{marginTop:12}}>
+      <div style={{ marginTop: 12 }}>
+        <div className="small">Connected peers:</div>
+        <ul>{peers.map(p => (<li key={p} className="small">{p}</li>))}</ul>
+      </div>
+      <div style={{ marginTop: 12 }}>
         <div className="small">Last incoming:</div>
-        <pre style={{whiteSpace:'pre-wrap'}}>{lastMsg? JSON.stringify(lastMsg, null, 2): 'None yet'}</pre>
+        <pre style={{ whiteSpace: 'pre-wrap' }}>{lastMsg ? JSON.stringify(lastMsg, null, 2) : 'None yet'}</pre>
       </div>
     </div>
   );

--- a/store.ts
+++ b/store.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { RtcSession } from './RtcSession';
 import { MeshRouter, Message } from './Mesh';
 
@@ -9,39 +9,117 @@ export function useRtcAndMesh() {
   const [status, setStatus] = useState('idle');
   const [lastMsg, setLastMsg] = useState<Message | null>(null);
   const [log, setLog] = useState<string[]>([]);
+  const [peers, setPeers] = useState<string[]>([]);
 
-  const rtc = useMemo(() => new RtcSession({ useStun, onOpen: ()=>push('dc-open'), onClose: r=>push('dc-close:'+r), onError: e=>push('dc-error:'+e), onState: s=>push(`ice:${s.ice}`) }), [useStun]);
   const mesh = useMemo(() => new MeshRouter(crypto.randomUUID()), []);
+  const sessionsRef = useRef<Map<string, RtcSession>>(new Map());
+  const pendingRtcRef = useRef<RtcSession | null>(null);
 
-  function push(s:string){ setLog((l)=>[s, ...l].slice(0,200)); }
+  function push(s: string) {
+    setLog((l) => [s, ...l].slice(0, 200));
+  }
 
-  useEffect(() => {
-    const onMsg = (raw: any) => {
-      try {
-        const msg: Message = JSON.parse(raw);
-        mesh.ingress(msg);
-        setLastMsg(msg);
-      } catch {
-        push('rx:non-json');
+  function createRtc(): RtcSession {
+    let peerId: string | null = null;
+    let rtc: RtcSession;
+    rtc = new RtcSession({
+      useStun,
+      onOpen: () => {
+        push('dc-open');
+        const hello: Message = {
+          id: crypto.randomUUID(),
+          ttl: 1,
+          from: mesh.selfId,
+          type: 'hello',
+          payload: {}
+        } as any;
+        try { rtc.send(JSON.stringify(hello)); } catch {}
+      },
+      onClose: (reason) => {
+        push('dc-close:' + reason);
+        if (peerId) {
+          mesh.disconnectPeer(peerId);
+          sessionsRef.current.delete(peerId);
+          setPeers(Array.from(sessionsRef.current.keys()));
+        }
+      },
+      onError: (e) => push('dc-error:' + e),
+      onState: (s) => push(`ice:${s.ice}`),
+      onMessage: (raw) => {
+        try {
+          const msg: Message = JSON.parse(raw as string);
+          if (!peerId) {
+            peerId = msg.from;
+            sessionsRef.current.set(peerId, rtc);
+            setPeers(Array.from(sessionsRef.current.keys()));
+            mesh.connectPeer(peerId, (m) => rtc.send(JSON.stringify(m)));
+          }
+          mesh.ingress(msg);
+          setLastMsg(msg);
+        } catch {
+          push('rx:non-json');
+        }
       }
-    };
-    (rtc as any).events.onMessage = onMsg; // bind
-    return () => { (rtc as any).events.onMessage = undefined; };
-  }, [mesh, rtc]);
-
-  function createOffer(){
-    return rtc.createOffer().then((o)=>{ setOfferJson(o); setStatus('offer-created'); return o;});
-  }
-  function acceptOfferAndCreateAnswer(remoteOffer: string){
-    return rtc.receiveOfferAndCreateAnswer(remoteOffer).then((a)=>{ setAnswerJson(a); setStatus('answer-created'); return a;});
-  }
-  function acceptAnswer(remoteAnswer: string){
-    return rtc.receiveAnswer(remoteAnswer).then(()=> setStatus('connected'));
-  }
-  function sendMesh(payload: any){
-    const msg: Message = { id: crypto.randomUUID(), ttl: 8, from: 'LOCAL', type: 'chat', payload } as any;
-    rtc.send(JSON.stringify(msg));
+    });
+    return rtc;
   }
 
-  return { useStun, setUseStun, createOffer, acceptOfferAndCreateAnswer, acceptAnswer, offerJson, answerJson, status, sendMesh, lastMsg, log };
+  function createOffer() {
+    const rtc = createRtc();
+    pendingRtcRef.current = rtc;
+    return rtc.createOffer().then((o) => {
+      setOfferJson(o);
+      setStatus('offer-created');
+      return o;
+    });
+  }
+
+  function acceptOfferAndCreateAnswer(remoteOffer: string) {
+    const rtc = createRtc();
+    pendingRtcRef.current = rtc;
+    return rtc.receiveOfferAndCreateAnswer(remoteOffer).then((a) => {
+      setAnswerJson(a);
+      setStatus('answer-created');
+      return a;
+    });
+  }
+
+  function acceptAnswer(remoteAnswer: string) {
+    const rtc = pendingRtcRef.current;
+    return rtc
+      ?.receiveAnswer(remoteAnswer)
+      .then(() => setStatus('connected'));
+  }
+
+  function sendMesh(payload: any, targets?: string[]) {
+    const msg: Message = {
+      id: crypto.randomUUID(),
+      ttl: 8,
+      from: mesh.selfId,
+      type: 'chat',
+      payload
+    } as any;
+    const ids = targets && targets.length ? targets : Array.from(sessionsRef.current.keys());
+    for (const id of ids) {
+      const rtc = sessionsRef.current.get(id);
+      try {
+        rtc?.send(JSON.stringify(msg));
+      } catch {}
+    }
+  }
+
+  return {
+    useStun,
+    setUseStun,
+    createOffer,
+    acceptOfferAndCreateAnswer,
+    acceptAnswer,
+    offerJson,
+    answerJson,
+    status,
+    sendMesh,
+    lastMsg,
+    log,
+    peers
+  };
 }


### PR DESCRIPTION
## Summary
- manage a map of `RtcSession` instances and handle peer lifecycle
- expose connected peer list and targeted messaging via `sendMesh`
- enhance chat UI to select peers and display connections

## Testing
- `npm install` (fails: Not Found - GET https://registry.npmjs.org/@types%2fjsqr)
- `npm test` (fails: vitest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b3d1d87ad88321bff1445b9877ce4d