### PR TITLE
feat: add mesh settings

### DIFF
--- a/Diagnostics.tsx
+++ b/Diagnostics.tsx
@@ -1,7 +1,14 @@
+import { useRtcAndMesh } from './store';
+
 export default function Diagnostics(){
+  const { ttl, setTtl, maxMessageSize, setMaxMessageSize } = useRtcAndMesh();
   return (
     <div className="card">
       <h2>Diagnostics</h2>
+      <div className="row" style={{gap:8, marginBottom:12}}>
+        <label>TTL <input type="number" value={ttl} onChange={e=>setTtl(Number(e.target.value))} /></label>
+        <label>Max Msg Size <input type="number" value={maxMessageSize} onChange={e=>setMaxMessageSize(Number(e.target.value))} /></label>
+      </div>
       <ul className="small">
         <li>User Agent: {navigator.userAgent}</li>
         <li>Online: {String(navigator.onLine)}</li>

--- a/Mesh.ts
+++ b/Mesh.ts
@@ -6,17 +6,27 @@ export type Message = { id: string; ttl: number; from: string; type: string; pay
 export class MeshRouter {
   private peers: Map<string, (msg: Message) => void> = new Map();
   private seen: Set<string> = new Set();
-  constructor(public readonly selfId: string) {}
+  constructor(
+    public readonly selfId: string,
+    private readonly defaultTtl: number = 8,
+    private readonly maxMessageSize: number = 1024,
+  ) {}
 
   connectPeer(id: string, handler: (msg: Message) => void) { this.peers.set(id, handler); }
   disconnectPeer(id: string) { this.peers.delete(id); }
 
-  send(msg: Omit<Message, 'from'>) {
-    const full: Message = { ...msg, from: this.selfId };
+  send(msg: Omit<Message, 'from' | 'ttl'> & { ttl?: number }) {
+    const full: Message = {
+      ...msg,
+      ttl: msg.ttl ?? this.defaultTtl,
+      from: this.selfId,
+    } as Message;
+    if (JSON.stringify(full).length > this.maxMessageSize) return;
     this.deliver(full);
   }
 
   private deliver(msg: Message) {
+    if (JSON.stringify(msg).length > this.maxMessageSize) return;
     if (this.seen.has(msg.id)) return;
     this.seen.add(msg.id);
     for (const [id, h] of this.peers) {

--- a/mesh.test.ts
+++ b/mesh.test.ts
@@ -3,9 +3,9 @@ import { MeshRouter, Message } from './Mesh';
 
 describe('MeshRouter', () => {
   it('honors TTL and dedupes', async () => {
-    const a = new MeshRouter('A');
-    const b = new MeshRouter('B');
-    const c = new MeshRouter('C');
+    const a = new MeshRouter('A', 8, 1024);
+    const b = new MeshRouter('B', 8, 1024);
+    const c = new MeshRouter('C', 8, 1024);
 
     const inboxC: Message[] = [];
 


### PR DESCRIPTION
## Summary
- add TTL and max message size settings to diagnostics panel
- wire mesh router to use configurable TTL and max message size
- update mesh router tests for new constructor options

## Testing
- `npm install` *(fails: Not Found - GET https://registry.npmjs.org/@types%2fjsqr)*
- `npx vitest run` *(fails: Cannot find package 'vitest' imported from vitest.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d1da6edc8321b8e9b08ffdc1493e