### PR TITLE
docs: add architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,12 @@ npm run dev
 npm run build
 ```
 
+## Architecture
+
+- `RtcSession.ts` – handles WebRTC data channel setup and messaging between peers.
+- `Mesh.ts` – provides an in-memory relay that forwards and deduplicates messages with TTL control.
+- `VoicePanel.tsx` – React component for managing local speech-to-text sessions and displaying transcripts.
+- `sw.js` – service worker implementing a network-first cache to keep the app functional offline.
+
 ## Netlify
 Uses `netlify.toml` to run `npm run build` and publish `dist`.


### PR DESCRIPTION
## Summary
- document high-level architecture with roles for RtcSession, Mesh, VoicePanel, and service worker

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d2133e9c832190328ee3f4b6511a