### PR TITLE
docs: add Whisper WASM model hosting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,19 @@ npm run dev
 npm run build
 ```
 
+## Whisper WASM models
+Whisper model binaries are not bundled in this repo.
+Download the desired `.bin` files (for example, `ggml-base.en.bin`) from the
+[whisper.cpp releases](https://huggingface.co/ggerganov/whisper.cpp/tree/main)
+or another trusted source.
+
+Host the models yourself under a `/models` directory so they can be fetched at
+runtime, e.g. `https://your.domain/models/ggml-base.en.bin`. The app expects
+the models to live at `/models/*` in production.
+
+Model files are sizable: the tiny model is ~35 MB, the base model is ~75 MB
+and larger models can exceed 300 MB. Ensure your hosting platform supports
+serving large static files and consider a CDN or object storage if needed.
+
 ## Netlify
 Uses `netlify.toml` to run `npm run build` and publish `dist`.


### PR DESCRIPTION
## Summary
- document how to obtain and self-host Whisper WASM model binaries
- note expected `/models` path and model size considerations

## Testing
- `npm test` (fails: vitest not found)
- `npm install` (fails: @types/jsqr package not found)


------
https://chatgpt.com/codex/tasks/task_e_68b3d217f2f08321895f76a18bb83079