### PR TITLE
feat: add AES-GCM helpers and encrypt mesh payload

### DIFF
--- a/envelope.ts
+++ b/envelope.ts
@@ -11,4 +11,27 @@ export async function generateKeyPair(): Promise<KeyPair> {
 export async function exportPublicKeyJwk(key: CryptoKey): Promise<JsonWebKey> {
   return crypto.subtle.exportKey('jwk', key);
 }
-// TODO: add AES-GCM envelope in v0.1
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+// Encrypt arbitrary JSON-serializable data with AES-GCM.
+export async function encrypt(key: CryptoKey, payload: any): Promise<string> {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const data = encoder.encode(JSON.stringify(payload));
+  const cipher = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data);
+  const buf = new Uint8Array(iv.length + cipher.byteLength);
+  buf.set(iv, 0);
+  buf.set(new Uint8Array(cipher), iv.length);
+  return btoa(String.fromCharCode(...buf));
+}
+
+// Decrypt data previously encrypted with `encrypt`.
+export async function decrypt(key: CryptoKey, b64: string): Promise<any> {
+  const raw = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
+  const iv = raw.slice(0, 12);
+  const data = raw.slice(12);
+  const plain = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data);
+  const text = decoder.decode(plain);
+  return JSON.parse(text);
+}

--- a/store.ts
+++ b/store.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { RtcSession } from './RtcSession';
 import { MeshRouter, Message } from './Mesh';
+import { encrypt, decrypt } from './envelope';
 
 export function useRtcAndMesh() {
   const [useStun, setUseStun] = useState(false);
@@ -12,13 +13,24 @@ export function useRtcAndMesh() {
 
   const rtc = useMemo(() => new RtcSession({ useStun, onOpen: ()=>push('dc-open'), onClose: r=>push('dc-close:'+r), onError: e=>push('dc-error:'+e), onState: s=>push(`ice:${s.ice}`) }), [useStun]);
   const mesh = useMemo(() => new MeshRouter(crypto.randomUUID()), []);
+  const aesKeyPromise = useMemo(() => crypto.subtle.generateKey(
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt', 'decrypt']
+  ), []);
 
   function push(s:string){ setLog((l)=>[s, ...l].slice(0,200)); }
 
   useEffect(() => {
-    const onMsg = (raw: any) => {
+    const onMsg = async (raw: any) => {
       try {
         const msg: Message = JSON.parse(raw);
+        try {
+          const key = await aesKeyPromise;
+          msg.payload = await decrypt(key, msg.payload);
+        } catch {
+          push('rx:decrypt-fail');
+        }
         mesh.ingress(msg);
         setLastMsg(msg);
       } catch {
@@ -38,8 +50,10 @@ export function useRtcAndMesh() {
   function acceptAnswer(remoteAnswer: string){
     return rtc.receiveAnswer(remoteAnswer).then(()=> setStatus('connected'));
   }
-  function sendMesh(payload: any){
-    const msg: Message = { id: crypto.randomUUID(), ttl: 8, from: 'LOCAL', type: 'chat', payload } as any;
+  async function sendMesh(payload: any){
+    const key = await aesKeyPromise;
+    const enc = await encrypt(key, payload);
+    const msg: Message = { id: crypto.randomUUID(), ttl: 8, from: 'LOCAL', type: 'chat', payload: enc } as any;
     rtc.send(JSON.stringify(msg));
   }
 


### PR DESCRIPTION
## Summary
- add AES-GCM `encrypt` and `decrypt` helpers in `envelope.ts`
- generate AES key in store and encrypt/decrypt mesh payloads

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d22dc6a88321b080af30fab964f0