### PR TITLE
Validate mesh messages before ingress

### DIFF
--- a/store.ts
+++ b/store.ts
@@ -18,9 +18,20 @@ export function useRtcAndMesh() {
   useEffect(() => {
     const onMsg = (raw: any) => {
       try {
-        const msg: Message = JSON.parse(raw);
-        mesh.ingress(msg);
-        setLastMsg(msg);
+        const msg: any = JSON.parse(raw);
+        if (
+          msg &&
+          typeof msg === 'object' &&
+          typeof msg.id === 'string' &&
+          typeof msg.ttl === 'number' &&
+          typeof msg.type === 'string' &&
+          'payload' in msg
+        ) {
+          mesh.ingress(msg as Message);
+          setLastMsg(msg as Message);
+        } else {
+          push('rx:invalid-schema');
+        }
       } catch {
         push('rx:non-json');
       }


### PR DESCRIPTION
## Summary
- add schema validation for mesh messages before calling `mesh.ingress`
- log and ignore messages failing validation

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b3d232b4b483219363e176a91ce9f8