### PR TITLE
Downscale video frame before jsQR scan

### DIFF
--- a/qr.ts
+++ b/qr.ts
@@ -19,9 +19,11 @@ export async function scanQRFromVideo(video: HTMLVideoElement, signal: AbortSign
     const tick = () => {
       if (signal.aborted) return reject(new Error('aborted'));
       if (video.readyState >= 2) {
-        canvas.width = video.videoWidth; canvas.height = video.videoHeight;
-        ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
-        const img = ctx.getImageData(0, 0, canvas.width, canvas.height);
+        const width = Math.floor(video.videoWidth / 2);
+        const height = Math.floor(video.videoHeight / 2);
+        canvas.width = width; canvas.height = height;
+        ctx.drawImage(video, 0, 0, width, height);
+        const img = ctx.getImageData(0, 0, width, height);
         const code = jsQR(img.data, img.width, img.height);
         if (code && code.data) { resolve(code.data); return; }
       }


### PR DESCRIPTION
## Summary
- Reduce QR scanning workload by halving video frame dimensions before invoking jsQR.

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run check` *(fails: tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d23534b48321b3db6aea5d4c5caa