### PR TITLE
Add error boundary around App component

### DIFF
--- a/ErrorBoundary.tsx
+++ b/ErrorBoundary.tsx
@@ -1,0 +1,30 @@
+import { Component, ReactNode, ErrorInfo } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(_error: unknown): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown, errorInfo: ErrorInfo) {
+    console.error('ErrorBoundary caught an error', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div>Something went wrong.</div>;
+    }
+
+    return this.props.children;
+  }
+}
+

--- a/main.tsx
+++ b/main.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import ErrorBoundary from './ErrorBoundary';
 import './styles.css';
 import './sw-register';
 
 createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- introduce `ErrorBoundary` component to display a fallback when rendering fails
- wrap `<App />` with the error boundary in `main.tsx`

## Testing
- `npm install` *(fails: Not Found - @types/jsqr)*
- `npx -y vitest run` *(fails: Cannot find package 'vitest')*


------
https://chatgpt.com/codex/tasks/task_e_68b3d26a89b48321994ecb467a7539f0