### PR TITLE
Add timestamp to mesh messages

### DIFF
--- a/mesh.test.ts
+++ b/mesh.test.ts
@@ -23,6 +23,7 @@ describe('MeshRouter', () => {
     expect(inboxC.length).toBeGreaterThan(0);
     const ids = new Set(inboxC.map(m => m.id));
     expect(ids.size).toBe(inboxC.length);
+    expect(typeof inboxC[0].timestamp).toBe('number');
 
     inboxC.length = 0;
     a.send({ id: 'y', ttl: 0, type: 'chat', payload: 'nope' } as any);


### PR DESCRIPTION
## Summary
- Add optional `timestamp` field to mesh messages and ensure it's populated when sending or forwarding
- Extend tests to confirm timestamps are included

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d270f6388321aaf4a2afa086bb5e