### PR TITLE
feat: add service worker diagnostics

### DIFF
--- a/Diagnostics.tsx
+++ b/Diagnostics.tsx
@@ -1,4 +1,40 @@
+import { useEffect, useState } from 'react';
+
 export default function Diagnostics(){
+  const [swStatus, setSwStatus] = useState('checking');
+  const [cacheCount, setCacheCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    async function check() {
+      if ('serviceWorker' in navigator) {
+        try {
+          const reg = await navigator.serviceWorker.getRegistration();
+          setSwStatus(reg ? 'registered' : 'not registered');
+        } catch {
+          setSwStatus('not registered');
+        }
+      } else {
+        setSwStatus('unsupported');
+      }
+
+      if ('caches' in window) {
+        try {
+          const keys = await caches.keys();
+          const counts = await Promise.all(keys.map(async key => {
+            const cache = await caches.open(key);
+            const entries = await cache.keys();
+            return entries.length;
+          }));
+          setCacheCount(counts.reduce((a, b) => a + b, 0));
+        } catch {
+          setCacheCount(0);
+        }
+      }
+    }
+
+    check();
+  }, []);
+
   return (
     <div className="card">
       <h2>Diagnostics</h2>
@@ -6,6 +42,8 @@ export default function Diagnostics(){
         <li>User Agent: {navigator.userAgent}</li>
         <li>Online: {String(navigator.onLine)}</li>
         <li>Service Worker: {'serviceWorker' in navigator ? 'yes' : 'no'}</li>
+        <li>SW Registered: {swStatus}</li>
+        <li>Cached Resources: {cacheCount === null ? 'checking' : cacheCount}</li>
         <li>Media Devices: {'mediaDevices' in navigator ? 'yes' : 'no'}</li>
         <li>Crypto Subtle: {'crypto' in window && 'subtle' in crypto ? 'yes' : 'no'}</li>
         <li>Camera Permissions: check browser address bar</li>


### PR DESCRIPTION
## Summary
- show service worker registration status
- display cached resource counts in diagnostics panel

## Testing
- `npx -y vitest run` *(fails: cannot find package 'vitest' imported from vitest.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d27939f08321be50c77da32193cf