### PR TITLE
Fix mesh TTL for local peers and simplify RTC data handling

### DIFF
--- a/Mesh.ts
+++ b/Mesh.ts
@@ -28,8 +28,11 @@ export class MeshRouter {
     this.seen.add(msg.id);
     for (const [id, h] of this.peers) {
       if (id === msg.from) continue; // no immediate echo back to sender id
-      if (msg.ttl <= 0 && !this.local.has(id)) continue;
-      const forwarded: Message = { ...msg, ttl: msg.ttl - 1 };
+
+      const isLocal = this.local.has(id);
+      if (msg.ttl <= 0 && !isLocal) continue;
+
+      const forwarded: Message = isLocal ? msg : { ...msg, ttl: msg.ttl - 1 };
       queueMicrotask(() => h(forwarded));
     }
   }

--- a/RtcSession.ts
+++ b/RtcSession.ts
@@ -37,7 +37,8 @@ export class RtcSession {
     dc.onopen = () => this.events.onOpen?.();
     dc.onclose = () => this.events.onClose?.('dc-close');
     dc.onerror = (e) => this.events.onError?.(e as any);
-    dc.onmessage = (m) => this.events.onMessage?.(typeof m.data === 'string' ? m.data : m.data);
+    // Forward incoming data to the consumer without unnecessary type juggling
+    dc.onmessage = (m) => this.events.onMessage?.(m.data);
   }
 
   async createOffer(): Promise<string> {
@@ -68,11 +69,8 @@ export class RtcSession {
     if (!this.dc || this.dc.readyState !== 'open') {
       throw new Error('DataChannel not open');
     }
-    if (typeof data === 'string') {
-      this.dc.send(data);
-    } else {
-      this.dc.send(data);
-    }
+    // RTCDataChannel#send accepts both string and ArrayBuffer directly
+    this.dc.send(data);
   }
 
   close() {


### PR DESCRIPTION
## Summary
- preserve TTL when forwarding to local peers in mesh router
- simplify RTC session data channel message handling and sending

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3e82c6d208321a2f41c9d381652ae