### PR TITLE
Fix STUN gather hang and add tests

### DIFF
--- a/RtcSession.test.ts
+++ b/RtcSession.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { RtcSession } from './RtcSession';
+
+class MockDataChannel {
+  readyState: RTCDataChannelState = 'open';
+  onopen?: ()=>void;
+  onclose?: ()=>void;
+  onerror?: (e:any)=>void;
+  onmessage?: (e:any)=>void;
+}
+
+class MockRTCPeerConnection {
+  public config: any;
+  public localDescription: any = null;
+  public oniceconnectionstatechange: any;
+  public ondatachannel: any;
+  public iceConnectionState: RTCIceConnectionState = 'new';
+  public iceGatheringState: RTCIceGatheringState = 'new';
+  constructor(config: any){ this.config = config; }
+  addEventListener(){}
+  removeEventListener(){}
+  createDataChannel(){ return new MockDataChannel() as any; }
+  createOffer(){ return Promise.resolve({}); }
+  setLocalDescription(desc: any){ this.localDescription = desc; return Promise.resolve(); }
+  createAnswer(){ return Promise.resolve({}); }
+  setRemoteDescription(){ return Promise.resolve(); }
+  close(){}
+}
+
+// @ts-ignore
+globalThis.RTCPeerConnection = MockRTCPeerConnection as any;
+
+describe('RtcSession', () => {
+  it('uses STUN server when enabled', () => {
+    const s = new RtcSession({ useStun: true });
+    // @ts-ignore accessing private for test
+    expect((s as any).pc.config.iceServers).toEqual([
+      { urls: 'stun:stun.l.google.com:19302' },
+    ]);
+  });
+
+  it('waitIceComplete resolves even if ICE never completes', async () => {
+    const s = new RtcSession({});
+    const start = Date.now();
+    // @ts-ignore accessing private for test
+    await (s as any).waitIceComplete(10);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(50);
+  });
+});

--- a/RtcSession.ts
+++ b/RtcSession.ts
@@ -80,14 +80,26 @@ export class RtcSession {
     this.pc.close();
   }
 
-  private waitIceComplete(): Promise<void> {
+  // Wait for ICE gathering to finish but don't hang forever if it never
+  // completes (which can happen if a STUN server is unreachable). The
+  // optional timeout is mainly for tests; in production the default value is
+  // long enough that candidates usually finish gathering.
+  private waitIceComplete(timeoutMs = 2000): Promise<void> {
     if (this.pc.iceGatheringState === 'complete') return Promise.resolve();
     return new Promise((resolve) => {
       const check = () => {
         if (this.pc.iceGatheringState === 'complete') {
-          this.pc.removeEventListener('icegatheringstatechange', check);
+          cleanup();
           resolve();
         }
+      };
+      const timer = setTimeout(() => {
+        cleanup();
+        resolve();
+      }, timeoutMs);
+      const cleanup = () => {
+        clearTimeout(timer);
+        this.pc.removeEventListener('icegatheringstatechange', check);
       };
       this.pc.addEventListener('icegatheringstatechange', check);
     });


### PR DESCRIPTION
## Summary
- prevent waitIceComplete from hanging indefinitely when STUN servers fail by adding timeout fallback
- add tests verifying STUN server configuration and timeout behavior

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b3e8bbf51483219ad812551807831b