### PR TITLE
feat: support ArrayBufferView payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sovereign Voice Mesh — v0 (Flattened)
+# Sovereign Voice Mesh — v0.0.5 (Flattened)
 
 All files are in the repo root for phone-friendly GitHub upload. Netlify-ready.
 

--- a/RtcSession.ts
+++ b/RtcSession.ts
@@ -65,12 +65,19 @@ export class RtcSession {
     await this.pc.setRemoteDescription(remote);
   }
 
-  send(data: string | ArrayBuffer) {
+  send(data: string | ArrayBuffer | ArrayBufferView) {
     if (!this.dc || this.dc.readyState !== 'open') {
       throw new Error('DataChannel not open');
     }
-    // RTCDataChannel#send accepts both string and ArrayBuffer directly
-    this.dc.send(data);
+    // RTCDataChannel#send accepts strings or ArrayBufferView directly. Convert
+    // bare ArrayBuffer payloads to a view to satisfy TypeScript's overloads.
+    if (typeof data === 'string') {
+      this.dc.send(data);
+    } else if (ArrayBuffer.isView(data)) {
+      this.dc.send(data as ArrayBufferView<ArrayBuffer>);
+    } else {
+      this.dc.send(new Uint8Array(data));
+    }
   }
 
   close() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sovereign-voice-mesh",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sovereign-voice-mesh",
-      "version": "0.0.1",
+      "version": "0.0.5",
       "dependencies": {
         "jsqr": "^1.4.0",
         "qrcode": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sovereign-voice-mesh",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- allow sending `ArrayBufferView` over RTC data channel, converting raw `ArrayBuffer` values to typed views
- bump project version to v0.0.5 and update documentation

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b4c5fd81948321a491234b5e644a46