### PR TITLE
fix: stabilize QR camera scanning

### DIFF
--- a/QRPairing.tsx
+++ b/QRPairing.tsx
@@ -21,8 +21,9 @@ export default function QRPairing(){
     abortRef.current?.abort();
     abortRef.current = new AbortController();
     setScannerOn(true);
-    const stream = await startVideo(videoRef.current);
+    let stream: MediaStream | null = null;
     try {
+      stream = await startVideo(videoRef.current);
       const data = await scanQRFromVideo(videoRef.current, abortRef.current.signal);
       if (data.length > 2048) throw new Error('QR data too large');
       try { JSON.parse(data); } catch { throw new Error('invalid JSON'); }
@@ -30,7 +31,12 @@ export default function QRPairing(){
     } catch(e){
       alert(String((e as any)?.message || e));
     } finally {
-      stream.getTracks().forEach(t=>t.stop());
+      if(stream){
+        stream.getTracks().forEach(t=>t.stop());
+      }
+      if(videoRef.current){
+        videoRef.current.srcObject = null;
+      }
       setScannerOn(false);
     }
   }
@@ -70,8 +76,9 @@ export default function QRPairing(){
     abortRef.current?.abort();
     abortRef.current = new AbortController();
     setScannerOn(true);
-    const stream = await startVideo(videoRef.current);
+    let stream: MediaStream | null = null;
     try {
+      stream = await startVideo(videoRef.current);
       const data = await scanQRFromVideo(videoRef.current, abortRef.current.signal);
       if (data.length > 2048) throw new Error('QR data too large');
       try { JSON.parse(data); } catch { throw new Error('invalid JSON'); }
@@ -79,7 +86,12 @@ export default function QRPairing(){
     } catch(e){
       alert(String((e as any)?.message || e));
     } finally {
-      stream.getTracks().forEach(t=>t.stop());
+      if(stream){
+        stream.getTracks().forEach(t=>t.stop());
+      }
+      if(videoRef.current){
+        videoRef.current.srcObject = null;
+      }
       setScannerOn(false);
     }
   }


### PR DESCRIPTION
## Summary
- ensure mobile-friendly video setup when initializing camera
- add robust abort handling for QR scanning loop
- cleanly stop and release camera stream after scanning

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b4de1debc8832182e3c4ec760afea2