### PR TITLE
feat: add websocket fallback and diagnostics

### DIFF
--- a/Chat.tsx
+++ b/Chat.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import DOMPurify from 'dompurify';
 
 export default function Chat(){
-  const { sendMesh, messages, addMessage, clearMessages } = useRtcAndMesh();
+  const { sendMesh, messages, addMessage, clearMessages, status } = useRtcAndMesh();
   const [text, setText] = useState('');
 
   async function send(){
@@ -21,6 +21,7 @@ export default function Chat(){
   return (
     <div className="card">
       <h2>Chat</h2>
+      {status !== 'connected' && <div className="small">Status: {status}</div>}
       <div className="row">
         <input value={text} onChange={e=>setText(e.target.value)} placeholder="Message" />
         <button onClick={send} title="Send message over DataChannel">Send</button>
@@ -35,7 +36,9 @@ export default function Chat(){
             </div>
           )) : 'None yet'}
         </div>
-        {messages.length > 0 && <button onClick={onClear} title="Clear chat history" style={{marginTop:8}}>Clear history</button>}
+        {messages.length > 0 && (
+          <button onClick={onClear} title="Clear chat history" style={{marginTop:8}}>Clear history</button>
+        )}
       </div>
     </div>
   );

--- a/Diagnostics.tsx
+++ b/Diagnostics.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 export default function Diagnostics(){
   const [swStatus, setSwStatus] = useState('checking');
   const [cacheCount, setCacheCount] = useState<number | null>(null);
+  const [netInfo, setNetInfo] = useState<{type?:string; effectiveType?:string; rtt?:number; downlink?:number}>({});
 
   useEffect(() => {
     async function check() {
@@ -34,6 +35,13 @@ export default function Diagnostics(){
       }
     }
     check();
+    const conn = (navigator as any).connection;
+    if(conn){
+      const update = () => setNetInfo({ type: conn.type, effectiveType: conn.effectiveType, rtt: conn.rtt, downlink: conn.downlink });
+      update();
+      conn.addEventListener('change', update);
+      return () => conn.removeEventListener('change', update);
+    }
   }, []);
 
   return (
@@ -45,6 +53,10 @@ export default function Diagnostics(){
         <li>Service Worker: {'serviceWorker' in navigator ? 'yes' : 'no'}</li>
         <li>SW Registered: {swStatus}</li>
         <li>Cached Resources: {cacheCount === null ? 'checking' : cacheCount}</li>
+        <li>Network Type: {netInfo.type || 'unknown'}</li>
+        <li>Effective Type: {netInfo.effectiveType || 'unknown'}</li>
+        <li>Nominal RTT: {netInfo.rtt ?? 'n/a'}</li>
+        <li>Downlink (Mbps): {netInfo.downlink ?? 'n/a'}</li>
         <li>Media Devices: {'mediaDevices' in navigator ? 'yes' : 'no'}</li>
         <li>Crypto Subtle: {'crypto' in window && 'subtle' in crypto ? 'yes' : 'no'}</li>
         <li>Camera Permissions: check browser address bar</li>

--- a/WebSocketSession.ts
+++ b/WebSocketSession.ts
@@ -1,0 +1,83 @@
+import { RtcEvents } from './RtcSession';
+
+export type WsOptions = RtcEvents & { url: string; heartbeatMs?: number };
+
+export class WebSocketSession {
+  public events: RtcEvents;
+  private ws?: WebSocket;
+  private heartbeatMs: number;
+  private hbTimer?: any;
+  private lastPing = 0;
+  private lastPong = Date.now();
+  private rtt = 0;
+  private url: string;
+
+  constructor(opts: WsOptions) {
+    this.events = opts;
+    this.url = opts.url;
+    this.heartbeatMs = opts.heartbeatMs ?? 5000;
+    this.connect();
+  }
+
+  private connect() {
+    this.ws = new WebSocket(this.url);
+    this.ws.onopen = () => {
+      this.startHeartbeat();
+      this.events.onOpen?.();
+      this.events.onState?.({ ice: 'ws', dc: 'open', rtt: this.rtt });
+    };
+    this.ws.onclose = (e) => {
+      this.stopHeartbeat();
+      this.events.onClose?.(e.reason || 'ws-close');
+      this.events.onState?.({ ice: 'ws', dc: 'closed', rtt: this.rtt });
+    };
+    this.ws.onerror = (e) => this.events.onError?.(e as any);
+    this.ws.onmessage = (m) => {
+      const data = m.data;
+      if (data === 'ping') { try { this.ws?.send('pong'); } catch {} return; }
+      if (data === 'pong') {
+        this.lastPong = Date.now();
+        this.rtt = this.lastPong - this.lastPing;
+        this.events.onState?.({ ice: 'ws', dc: 'open', rtt: this.rtt });
+        return;
+      }
+      this.events.onMessage?.(data);
+    };
+  }
+
+  send(data: string | ArrayBuffer | ArrayBufferView) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) throw new Error('WebSocket not open');
+    if (typeof data === 'string') {
+      this.ws.send(data);
+    } else {
+      const buf = data instanceof ArrayBuffer ? new Uint8Array(data) : data;
+      this.ws.send(buf as any);
+    }
+  }
+
+  close() {
+    this.stopHeartbeat();
+    this.ws?.close();
+  }
+
+  private startHeartbeat() {
+    this.stopHeartbeat();
+    this.hbTimer = setInterval(() => {
+      try {
+        this.lastPing = Date.now();
+        this.send('ping');
+      } catch {}
+      if (Date.now() - this.lastPong > this.heartbeatMs * 2) {
+        this.events.onClose?.('timeout');
+        this.close();
+      }
+    }, this.heartbeatMs);
+  }
+
+  private stopHeartbeat() {
+    if (this.hbTimer) clearInterval(this.hbTimer);
+  }
+
+  getStats() { return { rtt: this.rtt }; }
+}
+


### PR DESCRIPTION
## Summary
- surface connection status in Chat
- add WebSocket transport with heartbeat fallback
- track network info and RTT diagnostics

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b4de7ecd0083219cf58090c6b940da