### PR TITLE
feat: add verbose logging with viewer

### DIFF
--- a/Diagnostics.tsx
+++ b/Diagnostics.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
+import { getLogLines, downloadLogs } from './logger';
 
 export default function Diagnostics(){
   const [swStatus, setSwStatus] = useState('checking');
   const [cacheCount, setCacheCount] = useState<number | null>(null);
   const [netInfo, setNetInfo] = useState<{type?:string; effectiveType?:string; rtt?:number; downlink?:number}>({});
+  const [showLogs, setShowLogs] = useState(false);
 
   useEffect(() => {
     async function check() {
@@ -61,6 +63,13 @@ export default function Diagnostics(){
         <li>Crypto Subtle: {'crypto' in window && 'subtle' in crypto ? 'yes' : 'no'}</li>
         <li>Camera Permissions: check browser address bar</li>
       </ul>
+      <div className="row" style={{gap:8, marginTop:12}}>
+        <button onClick={() => setShowLogs(!showLogs)}>{showLogs ? 'Hide Logs' : 'Show Logs'}</button>
+        <button onClick={downloadLogs}>Download Logs</button>
+      </div>
+      {showLogs && (
+        <pre className="small" style={{maxHeight:200, overflow:'auto', marginTop:12}}>{getLogLines().join('\n')}</pre>
+      )}
     </div>
   );
 }

--- a/logger.ts
+++ b/logger.ts
@@ -1,0 +1,37 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'event' | 'rtc' | 'ws' | 'console';
+export interface LogEntry {
+  ts: number;
+  level: LogLevel;
+  message: string;
+}
+
+const entries: LogEntry[] = [];
+
+export function log(level: LogLevel, message: string) {
+  entries.push({ ts: Date.now(), level, message });
+  if (entries.length > 10000) entries.shift();
+}
+
+export function getLogLines(): string[] {
+  return entries.map(e => `${new Date(e.ts).toISOString()} [${e.level}] ${e.message}`);
+}
+
+export function downloadLogs() {
+  const blob = new Blob(getLogLines().join('\n'), { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'logs.txt';
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+['log','info','warn','error','debug'].forEach((lvl) => {
+  const orig = (console as any)[lvl];
+  (console as any)[lvl] = (...args: any[]) => {
+    try {
+      log('console', args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+    } catch {}
+    orig.apply(console, args);
+  };
+});


### PR DESCRIPTION
## Summary
- add global logger capturing console and events
- hook RtcSession and WebSocketSession with detailed logs
- expose log viewer and download button in diagnostics

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e2c0cfb0832187ce021219a56a6c