### PR TITLE
chore: enforce version bump in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
+      - run: node ./check-version-bump.mjs
       - run: npm install
       - run: npm test
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sovereign Voice Mesh — v0.0.7 (Flattened)
+# Sovereign Voice Mesh — v0.0.8 (Flattened)
 
 All files are in the repo root for phone-friendly GitHub upload. Netlify-ready.
 
@@ -12,6 +12,12 @@ npm run dev
 ```bash
 npm run build
 ```
+
+## Versioning
+
+Every pull request must bump the `version` field in `package.json`. CI runs
+`check-version-bump.mjs` to ensure the version changed compared to the previous
+commit.
 
 ## Architecture
 

--- a/check-version-bump.mjs
+++ b/check-version-bump.mjs
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+try {
+  const current = JSON.parse(readFileSync('package.json', 'utf8')).version;
+  const previousPkg = execSync('git show HEAD~1:package.json', {
+    encoding: 'utf8',
+  });
+  const previous = JSON.parse(previousPkg).version;
+  if (current === previous) {
+    console.error(
+      `Error: package.json version (${current}) has not been bumped since previous commit.`
+    );
+    process.exit(1);
+  }
+} catch (err) {
+  console.error('Failed to verify version bump:', err.message || err);
+  process.exit(1);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sovereign-voice-mesh",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sovereign-voice-mesh",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "dependencies": {
         "dompurify": "^3.2.6",
         "jsqr": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sovereign-voice-mesh",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- add script to fail if package.json version wasn't bumped
- run version check in CI
- document version bump requirement

## Testing
- `node check-version-bump.mjs`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4e6d1e3608321ad23e5afc9477f68