### PR TITLE
Fix voice worker to decode audio before transcription

### DIFF
--- a/voice_index.ts
+++ b/voice_index.ts
@@ -2,7 +2,7 @@ export type VoiceWorkerCmd =
   | { type: 'init'; model: string }
   | { type: 'start' }
   | { type: 'stop' }
-  | { type: 'transcribeBlob'; blob: Blob };
+  | { type: 'transcribeData'; data: Float32Array; rate: number };
 
 export type VoiceWorkerEvt =
   | { type: 'status'; status: string }
@@ -23,7 +23,13 @@ export class VoiceClient {
   }
 
   on(fn: (e: VoiceWorkerEvt) => void) { this.listeners.add(fn); return () => this.listeners.delete(fn); }
-  post(cmd: VoiceWorkerCmd) { this.worker.postMessage(cmd); }
+  post(cmd: VoiceWorkerCmd) {
+    if (cmd.type === 'transcribeData') {
+      this.worker.postMessage(cmd, [cmd.data.buffer]);
+    } else {
+      this.worker.postMessage(cmd);
+    }
+  }
   dispose() {
     this.worker.terminate();
     this.listeners.clear();

--- a/voice_worker.ts
+++ b/voice_worker.ts
@@ -1,5 +1,5 @@
 // Whisper speech-to-text worker powered by @xenova/transformers
-// Receives audio blobs from the main thread and returns transcription results.
+// Receives audio data from the main thread and returns transcription results.
 
 type Cmd = import('./voice_index').VoiceWorkerCmd;
 
@@ -31,7 +31,7 @@ self.onmessage = async (ev) => {
       postMessage({ type: 'status', status: 'stopped' });
       return;
     }
-    if (cmd.type === 'transcribeBlob') {
+    if (cmd.type === 'transcribeData') {
       if (!running) {
         postMessage({ type: 'error', error: 'Not running' });
         return;
@@ -40,7 +40,7 @@ self.onmessage = async (ev) => {
         postMessage({ type: 'error', error: 'Model not initialized' });
         return;
       }
-      const result = await transcriber(cmd.blob);
+      const result = await transcriber(cmd.data, { sampling_rate: cmd.rate });
       const text = typeof result?.text === 'string' ? result.text : '';
       postMessage({ type: 'final', text });
       return;


### PR DESCRIPTION
## Summary
- decode recorded audio with `AudioContext` before sending to Whisper worker
- send Float32Array and sampling rate to worker and transcribe with proper sampling rate

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4f289c4bc8321ad345aaa82bf5672