### PR TITLE
Auto-load voice model in worker

### DIFF
--- a/VoicePanel.tsx
+++ b/VoicePanel.tsx
@@ -5,7 +5,6 @@ export default function VoicePanel() {
   const clientRef = useRef<VoiceClient>();
   const recorderRef = useRef<MediaRecorder | null>(null);
   const [status, setStatus] = useState('idle');
-  const [model, setModel] = useState('Xenova/whisper-tiny.en');
   const [partials, setPartials] = useState<string[]>([]);
   const [finals, setFinals] = useState<string[]>([]);
 
@@ -24,9 +23,6 @@ export default function VoicePanel() {
     };
   }, []);
 
-  async function init() {
-    clientRef.current?.post({ type: 'init', model });
-  }
   async function start() {
     clientRef.current?.post({ type: 'start' });
     if (!recorderRef.current) {
@@ -54,11 +50,7 @@ export default function VoicePanel() {
     <div className="row">
       <div className="col card">
         <h2>Voice (Local STT)</h2>
-        <label>
-          Model id <input value={model} onChange={(e) => setModel(e.target.value)} />
-        </label>
         <div className="row">
-          <button onClick={init} title="Load model">Init</button>
           <button onClick={start} title="Begin processing">Start</button>
           <button onClick={stop} title="Stop processing">Stop</button>
         </div>

--- a/voice_index.ts
+++ b/voice_index.ts
@@ -1,5 +1,4 @@
 export type VoiceWorkerCmd =
-  | { type: 'init'; model: string }
   | { type: 'start' }
   | { type: 'stop' }
   | { type: 'transcribeBlob'; blob: Blob };


### PR DESCRIPTION
## Summary
- Load whisper voice model automatically when voice worker starts
- Simplify voice worker API by removing manual init command
- Trim VoicePanel to only start/stop recording without model input

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4f67aa56483218fb9327141cc486d