### PR TITLE
Improve QR video scanning resolution

### DIFF
--- a/qr.ts
+++ b/qr.ts
@@ -31,8 +31,14 @@ export async function scanQRFromVideo(video: HTMLVideoElement, signal: AbortSign
     const tick = () => {
       if (signal.aborted) { cleanup(); return reject(new Error('aborted')); }
       if (video.readyState >= 2) {
-        const width = Math.floor(video.videoWidth / 2);
-        const height = Math.floor(video.videoHeight / 2);
+        let width = video.videoWidth;
+        let height = video.videoHeight;
+        const maxDim = 1024;
+        if (width > maxDim || height > maxDim) {
+          const scale = Math.min(maxDim / width, maxDim / height);
+          width = Math.floor(width * scale);
+          height = Math.floor(height * scale);
+        }
         canvas.width = width; canvas.height = height;
         ctx.drawImage(video, 0, 0, width, height);
         const img = ctx.getImageData(0, 0, width, height);


### PR DESCRIPTION
## Summary
- Use full video resolution up to 1024px when scanning QR codes to improve decoding reliability

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4fb5121388321a8d5ce0432bed10b