### PR TITLE
Improve WebSocket and RTC error reporting

### DIFF
--- a/WebSocketSession.ts
+++ b/WebSocketSession.ts
@@ -39,7 +39,10 @@ export class WebSocketSession {
       this.events.onState?.({ ice: 'ws', dc: 'closed', rtt: this.rtt });
     };
     this.ws.onerror = (e) => {
-      const err = e instanceof ErrorEvent ? e.message : (e as any)?.message || e.type || 'error';
+      const err =
+        e instanceof ErrorEvent
+          ? e.message
+          : (e as any)?.message || (e as any)?.reason || e.type || 'error';
       log('ws', 'error:' + err);
       this.events.onError?.(err);
     };

--- a/store.ts
+++ b/store.ts
@@ -124,31 +124,32 @@ export function useRtcAndMesh() {
     }
     const url = (import.meta as any).env?.VITE_WS_URL || 'wss://example.com/ws';
     log('ws', 'connecting:' + url);
-    const ws = new WebSocketSession({
-      url,
-      heartbeatMs: 5000,
-      onOpen: () => {
-        log('ws', 'open');
-        push('ws-open');
-        flushPending();
-        setStatus('connected');
-        wsBackoff.current = 1000;
-      },
-      onClose: (r) => {
-        log('ws', 'close:' + r);
-        push('ws-close');
-        setStatus('reconnecting');
-        scheduleWsReconnect();
-      },
-      onError: (e) => {
-        log('ws', 'error:' + e);
-        push('ws-error:' + e);
-      },
-      onState: (s) => {
-        log('ws', 'state:' + JSON.stringify(s));
-        if (s.rtt !== undefined) setRtt(s.rtt);
-      },
-    });
+      const ws = new WebSocketSession({
+        url,
+        heartbeatMs: 5000,
+        onOpen: () => {
+          log('ws', 'open');
+          push('ws-open');
+          flushPending();
+          setStatus('connected');
+          wsBackoff.current = 1000;
+        },
+        onClose: (r) => {
+          log('ws', 'close:' + r);
+          push('ws-close');
+          setStatus('reconnecting');
+          scheduleWsReconnect();
+        },
+        onError: (e) => {
+          const err = typeof e === 'string' ? e : (e as any)?.message || (e as any)?.type || String(e);
+          log('ws', 'error:' + err);
+          push('ws-error:' + err);
+        },
+        onState: (s) => {
+          log('ws', 'state:' + JSON.stringify(s));
+          if (s.rtt !== undefined) setRtt(s.rtt);
+        },
+      });
     (ws as any).events.onMessage = (rtc as any).events.onMessage;
     wsRef.current = ws;
   }
@@ -237,7 +238,8 @@ export function useRtcAndMesh() {
       setStatus('offer-created');
       return o;
     } catch (e) {
-      log('error', 'createOffer failed');
+      const err = e instanceof Error ? e.message : String(e);
+      log('error', 'createOffer failed:' + err);
       push('offer-error');
       setStatus('error');
       throw e;
@@ -253,7 +255,8 @@ export function useRtcAndMesh() {
       setStatus('answer-created');
       return a;
     } catch (e) {
-      log('error', 'acceptOffer failed:' + e);
+      const err = e instanceof Error ? e.message : String(e);
+      log('error', 'acceptOffer failed:' + err);
       push('answer-error');
       setStatus('error');
       throw e;
@@ -267,7 +270,8 @@ export function useRtcAndMesh() {
       await rtc.receiveAnswer(remoteAnswer);
       setStatus('connected');
     } catch (e) {
-      log('error', 'acceptAnswer failed');
+      const err = e instanceof Error ? e.message : String(e);
+      log('error', 'acceptAnswer failed:' + err);
       push('accept-error');
       setStatus('error');
       throw e;


### PR DESCRIPTION
## Summary
- Propagate WebSocket error details so logs no longer show `[object Event]`
- Include error messages when RTC offer/answer steps fail

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4fe83483c83218074b45cbb23a29a