### PR TITLE
feat: add audio-based pairing option

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,16 +1,21 @@
 import { useState } from 'react';
 import QRPairing from './QRPairing';
+import AudioPairing from './AudioPairing';
 import Chat from './Chat';
 import VoicePanel from './VoicePanel';
 import Diagnostics from './Diagnostics';
 const version = import.meta.env.VITE_APP_VERSION;
 
 export default function App() {
-  const [tab, setTab] = useState<'connect' | 'voice' | 'chat' | 'diagnostics'>(
+  const [
+    tab,
+    setTab,
+  ] = useState<'connect' | 'audio' | 'voice' | 'chat' | 'diagnostics'>(
     'connect',
   );
   const tabs = [
-    { key: 'connect', label: 'Connect' },
+    { key: 'connect', label: 'QR Connect' },
+    { key: 'audio', label: 'Audio Connect' },
     { key: 'voice', label: 'Voice' },
     { key: 'chat', label: 'Chat' },
     { key: 'diagnostics', label: 'Diagnostics' },
@@ -31,6 +36,7 @@ export default function App() {
         ))}
       </div>
       {tab === 'connect' && <QRPairing />}
+      {tab === 'audio' && <AudioPairing />}
       {tab === 'voice' && <VoicePanel />}
       {tab === 'chat' && <Chat />}
       {tab === 'diagnostics' && <Diagnostics />}

--- a/AudioPairing.tsx
+++ b/AudioPairing.tsx
@@ -1,0 +1,115 @@
+import { useRef, useState } from 'react';
+import { playAudioData, listenForAudioData } from './audio';
+import { useRtcAndMesh } from './store';
+
+export default function AudioPairing() {
+  const {
+    createOffer,
+    acceptOfferAndCreateAnswer,
+    acceptAnswer,
+    offerJson,
+    answerJson,
+    status,
+    log,
+  } = useRtcAndMesh();
+  const [listening, setListening] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  async function listenAndAcceptOffer() {
+    abortRef.current?.abort();
+    abortRef.current = new AbortController();
+    setListening(true);
+    try {
+      const data = await listenForAudioData(abortRef.current.signal);
+      await acceptOfferAndCreateAnswer(data);
+    } catch (e) {
+      alert(String((e as any)?.message || e));
+    } finally {
+      setListening(false);
+    }
+  }
+
+  async function listenAndAcceptAnswer() {
+    abortRef.current?.abort();
+    abortRef.current = new AbortController();
+    setListening(true);
+    try {
+      const data = await listenForAudioData(abortRef.current.signal);
+      await acceptAnswer(data);
+    } catch (e) {
+      alert(String((e as any)?.message || e));
+    } finally {
+      setListening(false);
+    }
+  }
+
+  return (
+    <div className="row">
+      <div className="col card">
+        <h2>Device A</h2>
+        <div className="row">
+          <button
+            onClick={async () => {
+              await createOffer();
+              if (offerJson) await playAudioData(offerJson);
+            }}
+            title="Create offer and play audio"
+          >
+            Play Offer Audio
+          </button>
+          <button
+            onClick={listenAndAcceptAnswer}
+            title="Listen for answer audio"
+          >
+            Listen for Answer
+          </button>
+        </div>
+        <p className="small">Offer length: {offerJson.length}</p>
+        <p className="small">Answer length: {answerJson.length}</p>
+      </div>
+
+      <div className="col card">
+        <h2>Device B</h2>
+        <div className="row">
+          <button onClick={listenAndAcceptOffer} title="Listen for offer audio">
+            Listen for Offer
+          </button>
+          <button
+            onClick={async () => {
+              if (answerJson) await playAudioData(answerJson);
+            }}
+            data-inert={!answerJson}
+            title={answerJson ? 'Play answer audio' : 'No answer yet'}
+          >
+            Play Answer Audio
+          </button>
+        </div>
+      </div>
+
+      <div className="col card">
+        <h2>Status</h2>
+        <p>
+          <b>{status}</b>
+        </p>
+        {listening && (
+          <button
+            onClick={() => {
+              abortRef.current?.abort();
+            }}
+            title="Cancel listening"
+          >
+            Cancel
+          </button>
+        )}
+        <h3>Event Log</h3>
+        <ul>
+          {log.map((l, i) => (
+            <li key={i} className="small">
+              {l}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ commit.
 - `Diagnostics.tsx` – displays network information and service-worker status.
 - `VoicePanel.tsx` – React component for managing local speech-to-text sessions and displaying transcripts.
 - `sw.js` – service worker implementing a network-first cache to keep the app functional offline.
+- `AudioPairing.tsx` – alternative peer handshake using audible tones when a camera isn't available.
 
 ## Whisper WASM models
 

--- a/audio.ts
+++ b/audio.ts
@@ -1,0 +1,135 @@
+const BIT_DURATION = 0.1; // seconds per bit
+const FREQ0 = 1200;
+const FREQ1 = 1800;
+const FREQ_START = 2400;
+const FREQ_END = 3000;
+
+function textToBits(text: string): number[] {
+  const bytes = new TextEncoder().encode(text);
+  const bits: number[] = [];
+  for (const b of bytes) {
+    for (let i = 7; i >= 0; i--) bits.push((b >> i) & 1);
+  }
+  return bits;
+}
+
+function bitsToText(bits: number[]): string {
+  const bytes: number[] = [];
+  for (let i = 0; i < bits.length; i += 8) {
+    let byte = 0;
+    for (let j = 0; j < 8 && i + j < bits.length; j++) {
+      byte = (byte << 1) | bits[i + j];
+    }
+    bytes.push(byte);
+  }
+  return new TextDecoder().decode(new Uint8Array(bytes));
+}
+
+function scheduleTone(
+  ctx: AudioContext,
+  gain: GainNode,
+  freq: number,
+  start: number,
+  duration: number,
+) {
+  const osc = ctx.createOscillator();
+  osc.frequency.value = freq;
+  osc.connect(gain);
+  osc.start(start);
+  osc.stop(start + duration);
+}
+
+export async function playAudioData(text: string) {
+  const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+  const gain = ctx.createGain();
+  gain.gain.value = 0.2;
+  gain.connect(ctx.destination);
+  const bits = textToBits(text);
+  let t = ctx.currentTime;
+  scheduleTone(ctx, gain, FREQ_START, t, BIT_DURATION * 2);
+  t += BIT_DURATION * 2;
+  for (const bit of bits) {
+    scheduleTone(ctx, gain, bit ? FREQ1 : FREQ0, t, BIT_DURATION);
+    t += BIT_DURATION;
+  }
+  scheduleTone(ctx, gain, FREQ_END, t, BIT_DURATION * 2);
+  t += BIT_DURATION * 2;
+  await new Promise((r) => setTimeout(r, (t - ctx.currentTime) * 1000));
+  await ctx.close();
+}
+
+export async function listenForAudioData(
+  signal: AbortSignal,
+  timeoutMs = 15000,
+): Promise<string> {
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+  const src = ctx.createMediaStreamSource(stream);
+  const analyser = ctx.createAnalyser();
+  analyser.fftSize = 2048;
+  src.connect(analyser);
+  const data = new Float32Array(analyser.frequencyBinCount);
+  const threshold = -60;
+  const freqIndex = (freq: number) =>
+    Math.round((freq / ctx.sampleRate) * analyser.fftSize);
+
+  return new Promise((resolve, reject) => {
+    let bits: number[] = [];
+    let interval: any;
+    let finished = false;
+    const cleanup = () => {
+      finished = true;
+      clearInterval(interval);
+      stream.getTracks().forEach((t) => t.stop());
+      ctx.close();
+    };
+    const timer = setTimeout(() => {
+      if (!finished) {
+        cleanup();
+        reject(new Error('timeout'));
+      }
+    }, timeoutMs);
+
+    const waitForStart = () => {
+      if (signal.aborted) {
+        cleanup();
+        reject(new Error('aborted'));
+        return;
+      }
+      analyser.getFloatFrequencyData(data);
+      if (data[freqIndex(FREQ_START)] > threshold) {
+        // start listening after the start tone duration
+        setTimeout(() => {
+          interval = setInterval(sampleBit, BIT_DURATION * 1000);
+        }, BIT_DURATION * 2 * 1000);
+      } else {
+        requestAnimationFrame(waitForStart);
+      }
+    };
+
+    const sampleBit = () => {
+      if (signal.aborted) {
+        cleanup();
+        reject(new Error('aborted'));
+        return;
+      }
+      analyser.getFloatFrequencyData(data);
+      const endMag = data[freqIndex(FREQ_END)];
+      if (endMag > threshold) {
+        clearInterval(interval);
+        cleanup();
+        resolve(bitsToText(bits));
+        return;
+      }
+      const mag0 = data[freqIndex(FREQ0)];
+      const mag1 = data[freqIndex(FREQ1)];
+      bits.push(mag1 > mag0 ? 1 : 0);
+    };
+
+    signal.addEventListener('abort', () => {
+      cleanup();
+      reject(new Error('aborted'));
+    });
+    waitForStart();
+  });
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sovereign-voice-mesh",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- add WebRTC pairing through audible tones for camera-less devices
- expose Audio Connect tab in UI
- document audio pairing in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b50600af408321858b70fdb199f3b6