### PR TITLE
Clear audio listener timeout on cleanup

### DIFF
--- a/audio.test.ts
+++ b/audio.test.ts
@@ -1,0 +1,42 @@
+import { listenForAudioData } from './audio';
+import { vi, describe, it, expect } from 'vitest';
+
+describe('listenForAudioData cleanup', () => {
+  it('clears timeout when aborted', async () => {
+    vi.useFakeTimers();
+
+    const getUserMedia = vi.fn().mockResolvedValue({
+      getTracks: () => [{ stop: vi.fn() }],
+    });
+
+    const mockCtx = {
+      sampleRate: 48000,
+      createMediaStreamSource: vi.fn().mockReturnValue({ connect: vi.fn() }),
+      createAnalyser: vi.fn().mockReturnValue({
+        fftSize: 0,
+        frequencyBinCount: 0,
+        connect: vi.fn(),
+        getFloatFrequencyData: vi.fn(),
+      }),
+      close: vi.fn(),
+    } as any;
+
+    const navigatorMock = { mediaDevices: { getUserMedia } };
+    vi.stubGlobal('navigator', navigatorMock as any);
+    vi.stubGlobal('window', {
+      AudioContext: vi.fn().mockImplementation(() => mockCtx),
+      navigator: navigatorMock,
+    } as any);
+    vi.stubGlobal('requestAnimationFrame', vi.fn());
+
+    const controller = new AbortController();
+    const promise = listenForAudioData(controller.signal, 1000);
+    controller.abort();
+    await expect(promise).rejects.toThrow('aborted');
+
+    expect(vi.getTimerCount()).toBe(0);
+
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+});

--- a/audio.ts
+++ b/audio.ts
@@ -77,13 +77,15 @@ export async function listenForAudioData(
     let bits: number[] = [];
     let interval: any;
     let finished = false;
+    let timer: ReturnType<typeof setTimeout>;
     const cleanup = () => {
       finished = true;
       clearInterval(interval);
+      clearTimeout(timer);
       stream.getTracks().forEach((t) => t.stop());
       ctx.close();
     };
-    const timer = setTimeout(() => {
+    timer = setTimeout(() => {
       if (!finished) {
         cleanup();
         reject(new Error('timeout'));


### PR DESCRIPTION
## Summary
- prevent lingering timers by clearing timeout in audio listener cleanup
- test that aborting audio listener leaves no pending timers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b51ef796a48321a70d0372aa339c7e