### PR TITLE
Sanitize chat messages on render

### DIFF
--- a/Chat.tsx
+++ b/Chat.tsx
@@ -12,10 +12,10 @@ export default function Chat() {
       alert('Enter a message');
       return;
     }
-    const clean = DOMPurify.sanitize(text);
     try {
-      await sendMesh({ text: clean });
-      addMessage({ text: clean, direction: 'outgoing', timestamp: Date.now() });
+      // Send raw text; sanitize only when rendering to prevent XSS.
+      await sendMesh({ text });
+      addMessage({ text, direction: 'outgoing', timestamp: Date.now() });
       setText('');
     } catch (e) {
       alert('Send failed');
@@ -63,6 +63,7 @@ export default function Chat() {
                     {m.direction === 'outgoing' ? '→' : '←'}
                   </div>
                   <pre style={{ whiteSpace: 'pre-wrap' }}>
+                    {/* Sanitize on render to prevent XSS */}
                     {DOMPurify.sanitize(m.text)}
                   </pre>
                 </div>

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ commit.
 - `sw.js` – service worker implementing a network-first cache to keep the app functional offline.
 - `AudioPairing.tsx` – alternative peer handshake using audible tones when a camera isn't available.
 
+## Security
+
+- Always sanitize message content at render time using `DOMPurify.sanitize` to prevent cross-site scripting (XSS). Messages are stored and transmitted as raw text.
+
 ## Whisper WASM models
 
 Whisper model binaries are not bundled in this repo. Download the desired `.bin` files (for example, `ggml-base.en.bin`) from the [whisper.cpp releases](https://huggingface.co/ggerganov/whisper.cpp/tree/main) or another trusted source.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sovereign-voice-mesh",
-  "version": "0.0.10",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sovereign-voice-mesh",
-      "version": "0.0.10",
+      "version": "0.0.13",
       "dependencies": {
         "@xenova/transformers": "^2.10.1",
         "dompurify": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sovereign-voice-mesh",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- send chat messages as raw text and sanitize only when rendering
- document render-time sanitization requirement
- bump version to 0.0.13

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b51eff1508832191b6103a7f8cf18e