### PR TITLE
Use typed transcriber and enable noImplicitAny

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "baseUrl": ".",
     "paths": {},
     "types": ["vite/client"],
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noImplicitAny": true
   },
   "include": ["**/*.ts", "**/*.tsx", "vite.config.ts"],
   "exclude": ["node_modules", "dist"]

--- a/voice_worker.ts
+++ b/voice_worker.ts
@@ -1,11 +1,12 @@
 // Whisper speech-to-text worker powered by @xenova/transformers
 // Receives audio blobs from the main thread and returns transcription results.
 
-type Cmd = import('./voice_index').VoiceWorkerCmd;
+import type { Pipeline } from '@xenova/transformers';
+import type { VoiceWorkerCmd } from './voice_index';
 
 const MODEL_ID = 'Xenova/whisper-tiny.en';
 let running = false;
-let transcriber: any = null;
+let transcriber: Pipeline | null = null;
 
 // Load the model immediately when the worker starts.
 (async () => {
@@ -19,8 +20,8 @@ let transcriber: any = null;
   }
 })();
 
-self.onmessage = async (ev) => {
-  const cmd = ev.data as Cmd;
+self.onmessage = async (ev: MessageEvent<VoiceWorkerCmd>) => {
+  const cmd = ev.data;
   try {
     if (cmd.type === 'start') {
       if (!transcriber) {


### PR DESCRIPTION
## Summary
- use `Pipeline` type for speech transcription worker and wire message handler to `VoiceWorkerCmd`
- enforce `noImplicitAny` to catch untyped params

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b51efc31408321b65c4ec867488cb8