### PR TITLE
Add WebSocket cleanup effect and reset backoff

### DIFF
--- a/store.ts
+++ b/store.ts
@@ -54,6 +54,15 @@ export function useRtcAndMesh() {
     generateKeyPair().then(setKeys);
   }, []);
 
+  useEffect(
+    () => () => {
+      wsTimer.current && clearTimeout(wsTimer.current);
+      wsRef.current?.close();
+      wsBackoff.current = 1000;
+    },
+    [],
+  );
+
   const rtc = useMemo(
     () =>
       new RtcSession({


### PR DESCRIPTION
## Summary
- add unmount effect to clear WebSocket timer, close connection, and reset backoff

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b51f0510c8832188784fd2e49b214a