### PR TITLE
feat: make console capture configurable

### DIFF
--- a/main.tsx
+++ b/main.tsx
@@ -4,6 +4,9 @@ import App from './App';
 import ErrorBoundary from './ErrorBoundary';
 import './styles.css';
 import './sw-register';
+import { enableConsoleCapture } from './logger';
+
+enableConsoleCapture();
 
 createRoot(document.getElementById('root')!).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- wrap console overrides in `enableConsoleCapture()` and export matching `disableConsoleCapture()`
- start app with console capture enabled to collect logs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b51f0ec9ac832186f82b6ee14bc9a9