### PR TITLE
Improve SDP parsing error handling

### DIFF
--- a/RtcSession.test.ts
+++ b/RtcSession.test.ts
@@ -75,4 +75,19 @@ describe('RtcSession', () => {
     s.close();
     await expect(s.createOffer()).resolves.toBeTypeOf('string');
   });
+
+  it('returns informative error on malformed SDP JSON', async () => {
+    const s = new RtcSession({});
+    await expect(
+      s.receiveOfferAndCreateAnswer('not json'),
+    ).rejects.toThrow('invalid sdp json');
+  });
+
+  it('returns informative error on incorrect SDP type', async () => {
+    const s = new RtcSession({});
+    const wrongType = JSON.stringify({ type: 'answer', sdp: '' });
+    await expect(
+      s.receiveOfferAndCreateAnswer(wrongType),
+    ).rejects.toThrow('invalid sdp type');
+  });
 });

--- a/RtcSession.ts
+++ b/RtcSession.ts
@@ -244,13 +244,17 @@ function parseSdp(
   json: string,
   expectedType: 'offer' | 'answer',
 ): RTCSessionDescriptionInit {
-  const obj = JSON.parse(json);
-  if (
-    typeof obj !== 'object' ||
-    obj.type !== expectedType ||
-    typeof obj.sdp !== 'string'
-  ) {
-    throw new Error('invalid sdp');
+  let obj: any;
+  try {
+    obj = JSON.parse(json);
+  } catch {
+    throw new Error('invalid sdp json');
+  }
+  if (typeof obj !== 'object' || typeof obj.sdp !== 'string' || typeof obj.type !== 'string') {
+    throw new Error('invalid sdp fields');
+  }
+  if (obj.type !== expectedType) {
+    throw new Error('invalid sdp type');
   }
   return obj;
 }


### PR DESCRIPTION
## Summary
- return more informative errors from `parseSdp`
- add tests for malformed JSON and incorrect SDP type

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b51f133c588321a88f2c0c9447d208