### PR TITLE
feat: migrate service worker to TypeScript

### DIFF
--- a/sw-register.ts
+++ b/sw-register.ts
@@ -1,6 +1,6 @@
 // Registers the basic SW for offline support.
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch(console.error);
+    navigator.serviceWorker.register('/sw.ts').catch(console.error);
   });
 }

--- a/sw.ts
+++ b/sw.ts
@@ -1,11 +1,17 @@
+/// <reference lib="webworker" />
+
 // Very small network-first SW that caches same-origin GET responses.
+export {};
+
 const CACHE = 'svm-cache-v1';
 const PRECACHE = ['/models/ggml-base.en.bin'];
-self.addEventListener('install', (e) => {
+
+self.addEventListener('install', (e: ExtendableEvent) => {
   e.waitUntil(caches.open(CACHE).then((c) => c.addAll(PRECACHE)));
   self.skipWaiting();
 });
-self.addEventListener('activate', (e) => {
+
+self.addEventListener('activate', (e: ExtendableEvent) => {
   e.waitUntil(
     (async () => {
       const keys = await caches.keys();
@@ -16,7 +22,8 @@ self.addEventListener('activate', (e) => {
     })(),
   );
 });
-self.addEventListener('fetch', (e) => {
+
+self.addEventListener('fetch', (e: FetchEvent) => {
   const req = e.request;
   const url = new URL(req.url);
   if (req.method !== 'GET' || url.origin !== location.origin) return;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,18 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
 
 export default defineConfig({
   plugins: [react()],
-  build: { target: 'es2022' },
+  build: {
+    target: 'es2022',
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        sw: resolve(__dirname, 'sw.ts'),
+      },
+    },
+  },
   worker: { format: 'es' },
   define: {
     'import.meta.env.VITE_APP_VERSION': JSON.stringify(


### PR DESCRIPTION
## Summary
- migrate service worker to TypeScript and include web worker typings
- register new `sw.ts` file and bundle it via Vite rollup input

## Testing
- `npm test`
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5201e93288321bd7d0d6c3396dc80