### PR TITLE
test: cover negative ttl and prune

### DIFF
--- a/mesh.test.ts
+++ b/mesh.test.ts
@@ -1,8 +1,16 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { MeshRouter, Message } from './Mesh';
+
+const flushMicrotasks = async () => {
+  // Ensure queued microtasks propagate through the mesh
+  await Promise.resolve();
+  await Promise.resolve();
+};
 
 describe('MeshRouter', () => {
   it('honors TTL and dedupes', async () => {
+    vi.useFakeTimers();
+
     const a = new MeshRouter('A');
     const b = new MeshRouter('B');
     const c = new MeshRouter('C');
@@ -18,7 +26,7 @@ describe('MeshRouter', () => {
     c.connectPeer('INBOX', (m) => inboxC.push(m), { local: true });
 
     a.send({ id: 'x', ttl: 2, type: 'chat', payload: 'hi' } as any);
-    await new Promise((r) => setTimeout(r, 10));
+    await flushMicrotasks();
 
     expect(inboxC.length).toBeGreaterThan(0);
     const ids = new Set(inboxC.map((m) => m.id));
@@ -27,7 +35,55 @@ describe('MeshRouter', () => {
 
     inboxC.length = 0;
     a.send({ id: 'y', ttl: 0, type: 'chat', payload: 'nope' } as any);
-    await new Promise((r) => setTimeout(r, 10));
+    await flushMicrotasks();
     expect(inboxC.length).toBe(0);
+
+    vi.useRealTimers();
+  });
+
+  it('drops negative TTL messages immediately', async () => {
+    vi.useFakeTimers();
+
+    const a = new MeshRouter('A');
+    const inbox: Message[] = [];
+    a.connectPeer('INBOX', (m) => inbox.push(m), { local: true });
+
+    a.send({ id: 'neg', ttl: -1, type: 'chat', payload: 'nope' } as any);
+    await flushMicrotasks();
+    expect(inbox.length).toBe(0);
+
+    a.send({ id: 'neg', ttl: 1, type: 'chat', payload: 'ok' } as any);
+    await flushMicrotasks();
+    expect(inbox.length).toBe(1);
+
+    vi.useRealTimers();
+  });
+
+  it('prunes seen ids after timeout', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const a = new MeshRouter('A');
+    const inbox: Message[] = [];
+    a.connectPeer('INBOX', (m) => inbox.push(m), { local: true });
+
+    a.send({ id: 'z', ttl: 1, type: 'chat', payload: 'hi' } as any);
+    await flushMicrotasks();
+    expect(inbox.length).toBe(1);
+
+    // Duplicate should be dropped while in seen window
+    a.send({ id: 'z', ttl: 1, type: 'chat', payload: 'hi again' } as any);
+    await flushMicrotasks();
+    expect(inbox.length).toBe(1);
+
+    // Advance beyond the seen TTL (5 minutes)
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+    // Should be delivered again after pruning
+    a.send({ id: 'z', ttl: 1, type: 'chat', payload: 'hi later' } as any);
+    await flushMicrotasks();
+    expect(inbox.length).toBe(2);
+
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- replace setTimeout usage in mesh tests with fake timers
- add case ensuring negative TTL messages are dropped immediately
- add test to verify `pruneSeen` clears old message IDs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52028b2708321a94d4ee3e3b89dae