### PR TITLE
Improve ErrorBoundary fallback UI

### DIFF
--- a/ErrorBoundary.tsx
+++ b/ErrorBoundary.tsx
@@ -6,6 +6,8 @@ interface Props {
 
 interface State {
   hasError: boolean;
+  error?: Error;
+  errorInfo?: ErrorInfo;
 }
 
 export default class ErrorBoundary extends Component<Props, State> {
@@ -17,11 +19,45 @@ export default class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: unknown, errorInfo: ErrorInfo) {
     console.error('ErrorBoundary caught an error', error, errorInfo);
+    this.setState({
+      error: error instanceof Error ? error : new Error(String(error)),
+      errorInfo,
+    });
   }
 
   render() {
     if (this.state.hasError) {
-      return <div>Something went wrong.</div>;
+      const { error, errorInfo } = this.state;
+      return (
+        <div className="card" style={{ maxWidth: 600, margin: '20px auto' }}>
+          <h2>Something went wrong.</h2>
+          {error && (
+            <div className="small" style={{ marginTop: 8 }}>
+              {error.message}
+            </div>
+          )}
+          {errorInfo && (
+            <pre
+              className="small"
+              style={{ whiteSpace: 'pre-wrap', marginTop: 8 }}
+            >
+              {errorInfo.componentStack}
+            </pre>
+          )}
+          <button
+            onClick={() =>
+              this.setState({
+                hasError: false,
+                error: undefined,
+                errorInfo: undefined,
+              })
+            }
+            style={{ marginTop: 12 }}
+          >
+            Try again
+          </button>
+        </div>
+      );
     }
     return this.props.children;
   }


### PR DESCRIPTION
## Summary
- show detailed error message and component stack when an error is caught
- allow user to retry by resetting ErrorBoundary state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5202c39ec83218d7a111f387d68dd