### PR TITLE
feat: enable log uploads

### DIFF
--- a/Diagnostics.tsx
+++ b/Diagnostics.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { getLogLines, downloadLogs } from './logger';
+import { getLogLines, downloadLogs, uploadLogs } from './logger';
 
 export default function Diagnostics() {
   const [swStatus, setSwStatus] = useState('checking');
@@ -84,6 +84,7 @@ export default function Diagnostics() {
           {showLogs ? 'Hide Logs' : 'Show Logs'}
         </button>
         <button onClick={downloadLogs}>Download Logs</button>
+        <button onClick={() => uploadLogs('/api/logs')}>Upload Logs</button>
       </div>
       {showLogs && (
         <pre

--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ commit.
 - `sw.js` – service worker implementing a network-first cache to keep the app functional offline.
 - `AudioPairing.tsx` – alternative peer handshake using audible tones when a camera isn't available.
 
+## Log Upload Endpoint
+
+The diagnostics panel can POST collected log lines to a server. The default
+client implementation sends a `POST` request to `/api/logs` with a JSON body:
+
+```json
+{
+  "lines": ["ISO_TIMESTAMP [level] message", "..."]
+}
+```
+
+Deploy a server route at `/api/logs` (or adjust the client) to receive and
+process these logs.
+
 ## Whisper WASM models
 
 Whisper model binaries are not bundled in this repo. Download the desired `.bin` files (for example, `ggml-base.en.bin`) from the [whisper.cpp releases](https://huggingface.co/ggerganov/whisper.cpp/tree/main) or another trusted source.

--- a/logger.ts
+++ b/logger.ts
@@ -36,6 +36,14 @@ export function downloadLogs() {
   setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
+export async function uploadLogs(endpoint: string) {
+  await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ lines: getLogLines() }),
+  });
+}
+
 ['log', 'info', 'warn', 'error', 'debug'].forEach((lvl) => {
   const orig = (console as any)[lvl];
   (console as any)[lvl] = (...args: any[]) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sovereign-voice-mesh",
-  "version": "0.0.10",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sovereign-voice-mesh",
-      "version": "0.0.10",
+      "version": "0.0.13",
       "dependencies": {
         "@xenova/transformers": "^2.10.1",
         "dompurify": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sovereign-voice-mesh",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- add `uploadLogs` helper to send log lines to a server
- expose Upload Logs button in diagnostics panel
- document server endpoint and payload format

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b52044ee1c83219286c529e49ee200