### PR TITLE
feat: buffer outgoing messages

### DIFF
--- a/RtcSession.test.ts
+++ b/RtcSession.test.ts
@@ -7,6 +7,9 @@ class MockDataChannel {
   onclose?: () => void;
   onerror?: (e: any) => void;
   onmessage?: (e: any) => void;
+  bufferedAmount = 0;
+  bufferedAmountLowThreshold = 0;
+  addEventListener() {}
   close() {}
 }
 

--- a/WebSocketSession.ts
+++ b/WebSocketSession.ts
@@ -1,11 +1,15 @@
 import { RtcEvents } from './RtcSession';
 import { log } from './logger';
 
+const BUFFER_THRESHOLD = 64 * 1024; // 64KB
+
 export type WsOptions = RtcEvents & { url: string; heartbeatMs?: number };
 
 export class WebSocketSession {
   public events: RtcEvents;
   private ws?: WebSocket;
+  private sendQueue: (string | ArrayBuffer | ArrayBufferView)[] = [];
+  private flushTimer?: any;
   private heartbeatMs: number;
   private hbTimer?: any;
   private lastPing = 0;
@@ -29,6 +33,7 @@ export class WebSocketSession {
       this.startHeartbeat();
       this.events.onOpen?.();
       this.events.onState?.({ ice: 'ws', dc: 'open', rtt: this.rtt });
+      this.flushQueue();
     };
     this.ws.onclose = (e) => {
       const reason = e.reason || 'ws-close';
@@ -70,12 +75,48 @@ export class WebSocketSession {
       log('ws', 'send failed: not open');
       throw new Error('WebSocket not open');
     }
+    if (this.ws.bufferedAmount > BUFFER_THRESHOLD || this.sendQueue.length) {
+      log('ws', 'queue send');
+      this.sendQueue.push(data);
+      this.scheduleFlush();
+      return;
+    }
+    this.rawSend(data);
+  }
+
+  private rawSend(data: string | ArrayBuffer | ArrayBufferView) {
+    if (!this.ws) return;
     log('ws', 'send:' + (typeof data === 'string' ? data : '[binary]'));
     if (typeof data === 'string') {
       this.ws.send(data);
     } else {
       const buf = data instanceof ArrayBuffer ? new Uint8Array(data) : data;
       this.ws.send(buf as any);
+    }
+  }
+
+  private scheduleFlush() {
+    if (this.flushTimer) return;
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = undefined;
+      this.flushQueue();
+    });
+  }
+
+  private flushQueue() {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    while (this.sendQueue.length && this.ws.bufferedAmount < BUFFER_THRESHOLD) {
+      const msg = this.sendQueue.shift();
+      if (msg !== undefined) this.rawSend(msg);
+    }
+    if (this.sendQueue.length === 0) {
+      if (this.flushTimer) {
+        clearTimeout(this.flushTimer);
+        this.flushTimer = undefined;
+      }
+      this.events.onDrain?.();
+    } else {
+      this.scheduleFlush();
     }
   }
 


### PR DESCRIPTION
## Summary
- queue RTC data until bufferedAmount drops and notify via onDrain
- buffer WebSocket sends when bufferedAmount is high
- support optional drain callbacks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b53787b3388321a3fef6a0324a4cf9