### PR TITLE
Guard mesh handlers with error logging

### DIFF
--- a/mesh.test.ts
+++ b/mesh.test.ts
@@ -30,4 +30,20 @@ describe('MeshRouter', () => {
     await new Promise((r) => setTimeout(r, 10));
     expect(inboxC.length).toBe(0);
   });
+
+  it('emits error events when a handler throws', async () => {
+    const router = new MeshRouter('A');
+    const errors: any[] = [];
+    router.addEventListener('error', (e: any) => errors.push(e.detail));
+
+    router.connectPeer('B', () => {
+      throw new Error('boom');
+    });
+
+    router.send({ id: 'z', ttl: 1, type: 'test', payload: null } as any);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(errors.length).toBe(1);
+    expect(errors[0].peerId).toBe('B');
+  });
 });


### PR DESCRIPTION
## Summary
- wrap mesh peer handler in try/catch and emit router-level error events
- log handler failures for debugging
- test error event dispatch when a handler throws

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b537825fcc8321be94bfa8b0641ac8