### PR TITLE
Handle microphone permission errors in audio listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ commit.
 - `VoicePanel.tsx` – React component for managing local speech-to-text sessions and displaying transcripts.
 - `sw.js` – service worker implementing a network-first cache to keep the app functional offline.
 - `AudioPairing.tsx` – alternative peer handshake using audible tones when a camera isn't available.
+- `audio.ts` – utilities for encoding/decoding data over sound. `listenForAudioData` throws
+  `mic-permission-denied`, `aborted`, and `timeout` errors so callers can display the
+  appropriate UI feedback.
 
 ## Whisper WASM models
 

--- a/audio.test.ts
+++ b/audio.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { listenForAudioData } from './audio';
+
+describe('listenForAudioData', () => {
+  it('throws mic-permission-denied when microphone access is denied', async () => {
+    const oldNavigator = (globalThis as any).navigator;
+    (globalThis as any).navigator = {
+      mediaDevices: {
+        getUserMedia: () =>
+          Promise.reject({ name: 'NotAllowedError' } as unknown as Error),
+      },
+    };
+
+    const controller = new AbortController();
+    await expect(
+      listenForAudioData(controller.signal),
+    ).rejects.toThrow('mic-permission-denied');
+
+    (globalThis as any).navigator = oldNavigator;
+  });
+});
+

--- a/audio.ts
+++ b/audio.ts
@@ -58,11 +58,24 @@ export async function playAudioData(text: string) {
   await ctx.close();
 }
 
+/**
+ * Listen for encoded audio and return the decoded text.
+ *
+ * Throws the following `Error` messages so callers can present specific UI:
+ * - `mic-permission-denied` – the user did not grant microphone access
+ * - `aborted` – the provided `AbortSignal` was triggered
+ * - `timeout` – no complete payload was detected before `timeoutMs`
+ */
 export async function listenForAudioData(
   signal: AbortSignal,
   timeoutMs = 15000,
 ): Promise<string> {
-  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  let stream: MediaStream;
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  } catch (err) {
+    throw new Error('mic-permission-denied');
+  }
   const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
   const src = ctx.createMediaStreamSource(stream);
   const analyser = ctx.createAnalyser();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sovereign-voice-mesh",
-  "version": "0.0.10",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sovereign-voice-mesh",
-      "version": "0.0.10",
+      "version": "0.0.13",
       "dependencies": {
         "@xenova/transformers": "^2.10.1",
         "dompurify": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sovereign-voice-mesh",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- wrap `navigator.mediaDevices.getUserMedia` in `listenForAudioData` with `try/catch`
- throw a `mic-permission-denied` error if microphone access fails
- document audio error cases and add unit test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5377f87d48321aae003fdc31e9436