### PR TITLE
feat: cap websocket outbox size

### DIFF
--- a/WebSocketSession.ts
+++ b/WebSocketSession.ts
@@ -17,6 +17,7 @@ export class WebSocketSession {
   private hb: Heartbeat;
   private url: string;
   private outbox: (string | ArrayBuffer | ArrayBufferView)[] = [];
+  private readonly maxOutboxSize = 100;
   private shouldReconnect: boolean;
   private reconnectDelay: number;
   private readonly minDelay: number;
@@ -111,6 +112,9 @@ export class WebSocketSession {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       log('ws', 'queue msg');
       this.outbox.push(data);
+      if (this.outbox.length > this.maxOutboxSize) {
+        this.outbox.splice(0, this.outbox.length - this.maxOutboxSize);
+      }
       return;
     }
     log('ws', 'send:' + (typeof data === 'string' ? data : '[binary]'));


### PR DESCRIPTION
## Summary
- limit WebSocketSession outbox to 100 messages and drop oldest when full

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b612002bec83219152a5d921c454b5