### PR TITLE
Send public key when keys ready and connection open

### DIFF
--- a/store.ts
+++ b/store.ts
@@ -140,6 +140,12 @@ export function useRtcAndMesh() {
     sendRaw(JSON.stringify(msg));
   }
 
+  useEffect(() => {
+    if (keys && status === 'connected') {
+      sendKey();
+    }
+  }, [keys, status]);
+
   function flushPending() {
     const items = pending.current.splice(0);
     log('debug', 'flushPending:' + items.length);


### PR DESCRIPTION
## Summary
- send public key after keys generated and connection established

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b611e117c48321a2c0d93a798cd3b3