### PR TITLE
Handle localStorage removal errors in clearMessages

### DIFF
--- a/store.ts
+++ b/store.ts
@@ -199,8 +199,14 @@ export function useRtcAndMesh() {
 
   function clearMessages() {
     setMessages([]);
-    if (typeof localStorage !== 'undefined')
-      localStorage.removeItem('chatMessages');
+    if (typeof localStorage !== 'undefined') {
+      try {
+        localStorage.removeItem('chatMessages');
+      } catch (e) {
+        const err = e instanceof Error ? e.message : String(e);
+        log('error', 'Failed to clear saved messages: ' + err);
+      }
+    }
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- wrap `clearMessages` localStorage access in try/catch
- log a friendly error if clearing saved chat messages fails

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b668e312e8832191e9335ee0d7a124