### PR TITLE
Reset heartbeat timer after clearing

### DIFF
--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -7,7 +7,7 @@ export type HeartbeatOptions = {
 
 export class Heartbeat {
   private intervalMs: number;
-  private timer?: any;
+  private timer: ReturnType<typeof setInterval> | undefined;
   private lastPing = 0;
   private lastPong = Date.now();
   public rtt = 0;
@@ -32,7 +32,10 @@ export class Heartbeat {
   }
 
   stop() {
-    if (this.timer) clearInterval(this.timer);
+    if (this.timer !== undefined) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
   }
 
   handle(data: string | ArrayBuffer): boolean {


### PR DESCRIPTION
## Summary
- Properly type heartbeat timer using `ReturnType<typeof setInterval>`
- Clear interval and reset timer reference on stop

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b66920ce788321af0011794354baaa