### PR TITLE
Reset wsRef on WebSocket closure

### DIFF
--- a/store.ts
+++ b/store.ts
@@ -172,6 +172,8 @@ export function useRtcAndMesh() {
         setStatus('connected');
       },
       onClose: (r) => {
+        if (wsRef.current !== ws) return;
+        wsRef.current = null;
         log('ws', 'close:' + r);
         push('ws-close');
         setStatus('reconnecting');


### PR DESCRIPTION
## Summary
- Clear `wsRef` when WebSocketSession closes to allow fallback reconnects
- Guard `onClose` to avoid duplicate close logs from stale sessions

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68b66a46d7ec8321aa109b812e8204ef