### PR TITLE
Improve WebSocket lifecycle and remove DOMPurify

### DIFF
--- a/Chat.tsx
+++ b/Chat.tsx
@@ -1,6 +1,5 @@
 import { useRtcAndMesh } from './store';
 import { useState } from 'react';
-import DOMPurify from 'dompurify';
 
 export default function Chat() {
   const { sendMesh, messages, addMessage, clearMessages, status } =
@@ -13,7 +12,7 @@ export default function Chat() {
       return;
     }
     try {
-      // Send raw text; sanitize only when rendering to prevent XSS.
+      // Send raw text; React will escape content when rendering.
       await sendMesh({ text });
       addMessage({ text, direction: 'outgoing', timestamp: Date.now() });
       setText('');
@@ -63,8 +62,7 @@ export default function Chat() {
                     {m.direction === 'outgoing' ? '→' : '←'}
                   </div>
                   <pre style={{ whiteSpace: 'pre-wrap' }}>
-                    {/* Sanitize on render to prevent XSS */}
-                    {DOMPurify.sanitize(m.text)}
+                    {m.text}
                   </pre>
                 </div>
               ))

--- a/QRPairing.tsx
+++ b/QRPairing.tsx
@@ -32,7 +32,11 @@ export default function QRPairing() {
   }, [answerJson]);
 
   async function beginOffer() {
-    await createOffer();
+    try {
+      await createOffer();
+    } catch (e) {
+      alert(String((e as any)?.message || e));
+    }
   }
   async function scanAndAcceptOffer() {
     if (!videoRef.current) return;

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ commit.
 
 ## Security
 
-- Always sanitize message content at render time using `DOMPurify.sanitize` to prevent cross-site scripting (XSS). Messages are stored and transmitted as raw text.
+- React escapes message content when rendering to prevent cross-site scripting (XSS). Messages are stored and transmitted as raw text.
 
 ## Whisper WASM models
 

--- a/WebSocketSession.ts
+++ b/WebSocketSession.ts
@@ -117,7 +117,9 @@ export class WebSocketSession {
       log('ws', 'queue msg');
       this.outbox.push(data);
       if (this.outbox.length > this.maxOutboxSize) {
-        this.outbox.splice(0, this.outbox.length - this.maxOutboxSize);
+        const drop = this.outbox.length - this.maxOutboxSize;
+        this.outbox.splice(0, drop);
+        log('ws', 'drop queued:' + drop);
       }
       return;
     }

--- a/envelope.ts
+++ b/envelope.ts
@@ -56,9 +56,6 @@ export async function decryptEnvelope(
   pub: CryptoKey,
 ): Promise<ArrayBuffer> {
   const key = await deriveAesGcmKey(priv, pub);
-  return crypto.subtle.decrypt(
-    { name: 'AES-GCM', iv: envelope.iv as any },
-    key,
-    envelope.ciphertext,
-  );
+  const params: AesGcmParams = { name: 'AES-GCM', iv: envelope.iv };
+  return crypto.subtle.decrypt(params, key, envelope.ciphertext);
 }

--- a/logger.ts
+++ b/logger.ts
@@ -32,7 +32,10 @@ export function downloadLogs() {
   const a = document.createElement('a');
   a.href = url;
   a.download = 'logs.txt';
+  a.style.display = 'none';
+  document.body.appendChild(a);
   a.click();
+  document.body.removeChild(a);
   setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.14",
       "dependencies": {
         "@xenova/transformers": "^2.10.1",
-        "dompurify": "^3.2.6",
         "jsqr": "^1.4.0",
         "qrcode": "^1.5.4",
         "react": "^18.2.0",
@@ -1444,13 +1443,6 @@
         "@types/react": "^18.0.0"
       }
     },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
@@ -2467,15 +2459,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sovereign-voice-mesh",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "private": true,
   "type": "module",
   "scripts": {
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@xenova/transformers": "^2.10.1",
-    "dompurify": "^3.2.6",
     "jsqr": "^1.4.0",
     "qrcode": "^1.5.4",
     "react": "^18.2.0",

--- a/store.ts
+++ b/store.ts
@@ -154,8 +154,9 @@ export function useRtcAndMesh() {
 
   function startWsFallback() {
     if (wsRef.current) {
-      log('ws', 'ws already connected');
-      return;
+      log('ws', 'closing existing ws');
+      wsRef.current.close();
+      wsRef.current = null;
     }
     const url = (import.meta as any).env?.VITE_WS_URL || 'wss://example.com/ws';
     log('ws', 'connecting:' + url);


### PR DESCRIPTION
## Summary
- remove DOMPurify and rely on React's escaping
- close existing WebSocket session before starting fallback
- add error handling and AES-GCM decryption params
- handle anchor element when downloading logs
- cap WebSocket outbox size and log dropped messages
- bump version to 0.0.15

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b66c846cbc83219633f52b86b405ae