### PR TITLE
Add file transfer messaging with encryption

### DIFF
--- a/FileTransfer.tsx
+++ b/FileTransfer.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import { useRtcAndMesh } from './store';
+
+export default function FileTransfer() {
+  const { sendFile, status } = useRtcAndMesh();
+  const [file, setFile] = useState<File | null>(null);
+  const [progress, setProgress] = useState(0);
+
+  async function onSend() {
+    if (!file) {
+      alert('Select a file');
+      return;
+    }
+    setProgress(0);
+    await sendFile(file, (sent, total) => {
+      setProgress(Math.round((sent / total) * 100));
+    });
+  }
+
+  return (
+    <div className="card">
+      <h2>File Transfer</h2>
+      {status !== 'connected' && <div className="small">Status: {status}</div>}
+      <div className="row" style={{ alignItems: 'center', gap: 8 }}>
+        <input
+          type="file"
+          onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
+          aria-label="Select file"
+        />
+        <button onClick={onSend} disabled={!file} aria-label="Send file">
+          Send
+        </button>
+      </div>
+      {progress > 0 && (
+        <div className="small" style={{ marginTop: 8 }}>
+          Progress: {progress}%
+        </div>
+      )}
+    </div>
+  );
+}

--- a/Mesh.ts
+++ b/Mesh.ts
@@ -1,9 +1,18 @@
+export type FileChunkPayload = {
+  name: string;
+  type: string;
+  size: number;
+  chunk: number;
+  total: number;
+  data: number[];
+};
+
 export type Message = {
   id: string;
   ttl: number;
   from: string;
   type: string;
-  payload: any;
+  payload: any | FileChunkPayload;
   timestamp?: number;
   enc?: boolean;
 };

--- a/RtcSession.test.ts
+++ b/RtcSession.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { RtcSession } from './RtcSession';
 
 class MockDataChannel {
@@ -89,5 +89,15 @@ describe('RtcSession', () => {
     await expect(s.receiveOfferAndCreateAnswer(wrongType)).rejects.toThrow(
       'invalid sdp type',
     );
+  });
+
+  it('sends ArrayBuffer data directly', () => {
+    const s = new RtcSession({});
+    const buf = new Uint8Array([1, 2, 3]).buffer;
+    const send = vi.fn();
+    // @ts-ignore accessing private field for test
+    (s as any).dc = { readyState: 'open', send };
+    s.send(buf);
+    expect(send).toHaveBeenCalledWith(buf);
   });
 });

--- a/RtcSession.ts
+++ b/RtcSession.ts
@@ -187,10 +187,11 @@ export class RtcSession {
     log('rtc', 'send:' + (typeof data === 'string' ? data : '[binary]'));
     if (typeof data === 'string') {
       this.dc.send(data);
+    } else if (data instanceof ArrayBuffer) {
+      // Send ArrayBuffer directly to avoid extra copies
+      this.dc.send(data);
     } else {
-      const buf = data instanceof ArrayBuffer ? new Uint8Array(data) : data;
-      // Cast to satisfy the overloaded RTCDataChannel.send signature
-      this.dc.send(buf as any);
+      this.dc.send(data as any);
     }
   }
 

--- a/file-transfer.test.ts
+++ b/file-transfer.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { MeshRouter, Message, FileChunkPayload } from './Mesh';
+import { encryptEnvelope, decryptEnvelope, generateKeyPair } from './envelope';
+
+async function sendFileThroughMesh(
+  file: File,
+  sender: MeshRouter,
+  receiver: MeshRouter,
+) {
+  const chunkSize = 16 * 1024;
+  const total = Math.ceil(file.size / chunkSize);
+  for (let i = 0; i < total; i++) {
+    const slice = file.slice(i * chunkSize, Math.min(file.size, (i + 1) * chunkSize));
+    const buf = await slice.arrayBuffer();
+    const payload: FileChunkPayload = {
+      name: file.name,
+      type: file.type,
+      size: file.size,
+      chunk: i,
+      total,
+      data: Array.from(new Uint8Array(buf)),
+    };
+    sender.send({ id: crypto.randomUUID(), ttl: 1, type: 'file', payload } as Message);
+  }
+}
+
+describe('file transfer', () => {
+  it('transfers a small file via mesh', async () => {
+    const a = new MeshRouter('A');
+    const b = new MeshRouter('B');
+    a.connectPeer('B', (m) => b.ingress(m));
+    b.connectPeer('A', (m) => a.ingress(m));
+    const received: number[] = [];
+    b.connectPeer(
+      'INBOX',
+      (m) => {
+        const p = m.payload as FileChunkPayload;
+        received.push(...p.data);
+      },
+      { local: true },
+    );
+
+    const data = new Uint8Array(40000); // 40KB sample
+    data.forEach((_, i) => (data[i] = i % 256));
+    const file = new File([data], 'sample.bin');
+
+    await sendFileThroughMesh(file, a, b);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(received.length).toBe(data.length);
+    expect(new Uint8Array(received)).toEqual(data);
+  });
+
+  it('encrypts and decrypts file chunks', async () => {
+    const a = await generateKeyPair();
+    const b = await generateKeyPair();
+    const buf = new Uint8Array([1, 2, 3, 4]).buffer;
+    const { iv, ciphertext } = await encryptEnvelope(buf, a.privateKey, b.publicKey);
+    const plain = await decryptEnvelope({ iv, ciphertext }, b.privateKey, a.publicKey);
+    expect(new Uint8Array(plain)).toEqual(new Uint8Array(buf));
+  });
+});


### PR DESCRIPTION
## Summary
- support `file` message payloads in mesh routing
- expose `sendFile` and `FileTransfer` component for chunked file uploads
- handle ArrayBuffer DataChannel sends and cover with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b67b4532f48321be26f40efef1a8c2