### PR TITLE
feat: configurable rtc servers and diagnostics

### DIFF
--- a/Diagnostics.tsx
+++ b/Diagnostics.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { getLogLines, downloadLogs, uploadLogs } from './logger';
+import { useRtcAndMesh } from './store';
 
 export default function Diagnostics() {
   const [swStatus, setSwStatus] = useState('checking');
@@ -12,6 +13,15 @@ export default function Diagnostics() {
   }>({});
   const [showLogs, setShowLogs] = useState(false);
   const [uploading, setUploading] = useState(false);
+
+  const {
+    stunUrl,
+    setStunUrl,
+    turnUrl,
+    setTurnUrl,
+    rtcStats,
+    wsStats,
+  } = useRtcAndMesh();
 
   useEffect(() => {
     async function check() {
@@ -79,6 +89,36 @@ export default function Diagnostics() {
           {'crypto' in window && 'subtle' in crypto ? 'yes' : 'no'}
         </li>
         <li>Camera Permissions: check browser address bar</li>
+      </ul>
+
+      <h3 style={{ marginTop: 12 }}>RTC Configuration</h3>
+      <label className="row" style={{ alignItems: 'center', gap: 4 }}>
+        STUN URL:
+        <input
+          type="text"
+          value={stunUrl}
+          onChange={(e) => setStunUrl(e.target.value)}
+          placeholder="stun:stun.l.google.com:19302"
+        />
+      </label>
+      <label className="row" style={{ alignItems: 'center', gap: 4 }}>
+        TURN URL:
+        <input
+          type="text"
+          value={turnUrl}
+          onChange={(e) => setTurnUrl(e.target.value)}
+          placeholder="turn:turn.example.com:3478"
+        />
+      </label>
+
+      <h3 style={{ marginTop: 12 }}>Connection Stats</h3>
+      <ul className="small">
+        <li>RTC ICE: {rtcStats.ice || 'n/a'}</li>
+        <li>RTC DC: {rtcStats.dc || 'n/a'}</li>
+        <li>RTC RTT: {rtcStats.rtt ?? 'n/a'}</li>
+        <li>WS ICE: {wsStats.ice || 'n/a'}</li>
+        <li>WS DC: {wsStats.dc || 'n/a'}</li>
+        <li>WS RTT: {wsStats.rtt ?? 'n/a'}</li>
       </ul>
       <div className="row" style={{ gap: 8, marginTop: 12 }}>
         <button onClick={() => setShowLogs(!showLogs)}>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ npm run dev
 npm run build
 ```
 
+## Configuration
+
+- STUN/TURN servers can be set from the in-app **Diagnostics** page. The URLs
+  are saved to local storage and used when establishing new WebRTC sessions.
+- The WebSocket fallback server is configured via the `VITE_WS_URL`
+  environment variable.
+
 ## Versioning
 
 Every pull request must bump the `version` field in `package.json`. CI runs

--- a/RtcSession.test.ts
+++ b/RtcSession.test.ts
@@ -50,12 +50,11 @@ class MockRTCPeerConnection {
 globalThis.RTCPeerConnection = MockRTCPeerConnection as any;
 
 describe('RtcSession', () => {
-  it('uses STUN server when enabled', () => {
-    const s = new RtcSession({ useStun: true });
+  it('uses provided ICE servers', () => {
+    const servers = [{ urls: 'stun:stun.l.google.com:19302' }];
+    const s = new RtcSession({ iceServers: servers });
     // @ts-ignore accessing private for test
-    expect((s as any).pc.config.iceServers).toEqual([
-      { urls: 'stun:stun.l.google.com:19302' },
-    ]);
+    expect((s as any).pc.config.iceServers).toEqual(servers);
   });
 
   it('waitIceComplete resolves even if ICE never completes', async () => {

--- a/WebSocketSession.ts
+++ b/WebSocketSession.ts
@@ -142,6 +142,10 @@ export class WebSocketSession {
   }
 
   getStats() {
-    return { rtt: this.hb.rtt };
+    return {
+      rtt: this.hb.rtt,
+      dc: this.ws?.readyState === WebSocket.OPEN ? 'open' : 'closed',
+      ice: 'ws',
+    };
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sovereign-voice-mesh",
-  "version": "0.0.14",
+  "version": "0.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sovereign-voice-mesh",
-      "version": "0.0.14",
+      "version": "0.0.16",
       "dependencies": {
         "@xenova/transformers": "^2.10.1",
         "jsqr": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sovereign-voice-mesh",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "private": true,
   "type": "module",
   "scripts": {

--- a/store.ts
+++ b/store.ts
@@ -20,6 +20,8 @@ export interface ChatMessage {
 
 export function useRtcAndMesh() {
   const [useStun, setUseStun] = useState(false);
+  const [stunUrl, setStunUrl] = useState('');
+  const [turnUrl, setTurnUrl] = useState('');
   const [offerJson, setOfferJson] = useState('');
   const [answerJson, setAnswerJson] = useState('');
   const [status, setStatus] = useState('idle');
@@ -27,6 +29,9 @@ export function useRtcAndMesh() {
   const [logLines, setLogLines] = useState<string[]>([]);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [rtt, setRtt] = useState(0);
+  const [rtcStats, setRtcStats] = useState<{ rtt?: number; ice?: string; dc?: string }>({});
+  const [wsStats, setWsStats] =
+    useState<{ rtt?: number; ice?: string; dc?: string }>({});
   const [netInfo, setNetInfo] = useState<{
     type?: string;
     effectiveType?: string;
@@ -36,6 +41,26 @@ export function useRtcAndMesh() {
 
   const pending = useRef<string[]>([]);
   const wsRef = useRef<WebSocketSession | null>(null);
+
+  useEffect(() => {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      const s = localStorage.getItem('useStun');
+      if (s) setUseStun(s === 'true');
+      const su = localStorage.getItem('stunUrl');
+      if (su) setStunUrl(su);
+      const tu = localStorage.getItem('turnUrl');
+      if (tu) setTurnUrl(tu);
+    } catch {}
+  }, []);
+  useEffect(() => {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      localStorage.setItem('useStun', String(useStun));
+      localStorage.setItem('stunUrl', stunUrl);
+      localStorage.setItem('turnUrl', turnUrl);
+    } catch {}
+  }, [useStun, stunUrl, turnUrl]);
 
   useEffect(() => {
     const conn = (navigator as any).connection;
@@ -59,10 +84,17 @@ export function useRtcAndMesh() {
     [],
   );
 
+  const iceServers = useMemo(() => {
+    const servers: RTCIceServer[] = [];
+    if (useStun && stunUrl) servers.push({ urls: stunUrl });
+    if (useStun && turnUrl) servers.push({ urls: turnUrl });
+    return servers;
+  }, [useStun, stunUrl, turnUrl]);
+
   const rtc = useMemo(
     () =>
       new RtcSession({
-        useStun,
+        iceServers,
         heartbeatMs: 5000,
         onOpen: () => {
           push('dc-open');
@@ -81,7 +113,7 @@ export function useRtcAndMesh() {
           if (s.rtt !== undefined) setRtt(s.rtt);
         },
       }),
-    [useStun],
+    [iceServers],
   );
   // Close previous session when options change
   useEffect(() => {
@@ -195,6 +227,14 @@ export function useRtcAndMesh() {
     (ws as any).events.onMessage = (rtc as any).events.onMessage;
     wsRef.current = ws;
   }
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setRtcStats(rtc.getStats());
+      setWsStats(wsRef.current?.getStats() || {});
+    }, 1000);
+    return () => clearInterval(id);
+  }, [rtc]);
 
   function addMessage(m: ChatMessage) {
     setMessages((list) => [...list, m]);
@@ -361,6 +401,10 @@ export function useRtcAndMesh() {
   return {
     useStun,
     setUseStun,
+    stunUrl,
+    setStunUrl,
+    turnUrl,
+    setTurnUrl,
     createOffer,
     acceptOfferAndCreateAnswer,
     acceptAnswer,
@@ -374,6 +418,8 @@ export function useRtcAndMesh() {
     addMessage,
     clearMessages,
     rtt,
+    rtcStats,
+    wsStats,
     netInfo,
   };
 }


### PR DESCRIPTION
## Summary
- allow custom STUN/TURN URLs and show connection stats in Diagnostics
- persist server settings and expose stats via `useRtcAndMesh`
- extend RTC/WebSocket sessions to report detailed metrics

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b67b4949bc8321832256b56092ee59