### PR TITLE
Add ECDSA key signatures for pubkey exchange

### DIFF
--- a/store.test.ts
+++ b/store.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { generateKeyPair, exportPublicKeyJwk, sign } from './envelope';
+import { verifyAndImportPubKey } from './store';
+
+const encoder = new TextEncoder();
+
+describe('pubkey verification', () => {
+  it('accepts valid signed key', async () => {
+    const kp = await generateKeyPair();
+    const jwk = await exportPublicKeyJwk(kp.ecdh.publicKey);
+    const sigKey = await exportPublicKeyJwk(kp.ecdsa.publicKey);
+    const data = encoder.encode(JSON.stringify(jwk));
+    const sigBuf = await sign(data.buffer, kp.ecdsa.privateKey);
+    const payload = { key: jwk, sig: Array.from(new Uint8Array(sigBuf)), sigKey };
+    const pub = await verifyAndImportPubKey(payload);
+    expect(pub.type).toBe('public');
+  });
+
+  it('rejects invalid signature', async () => {
+    const kp = await generateKeyPair();
+    const jwk = await exportPublicKeyJwk(kp.ecdh.publicKey);
+    const sigKey = await exportPublicKeyJwk(kp.ecdsa.publicKey);
+    const data = encoder.encode(JSON.stringify(jwk));
+    const sigBuf = await sign(data.buffer, kp.ecdsa.privateKey);
+    const tampered = new Uint8Array(sigBuf);
+    tampered[0] ^= 0xff;
+    const payload = { key: jwk, sig: Array.from(tampered), sigKey };
+    await expect(verifyAndImportPubKey(payload)).rejects.toThrow();
+  });
+});
+


### PR DESCRIPTION
## Summary
- Generate ECDH and ECDSA keypairs and expose sign/verify helpers
- Sign public key announcements and verify remote signatures before use
- Add tests for signature success and failure scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b67b5017f48321bfdaf6ba73eab404