### PR TITLE
Add ECDSA public key signing

### DIFF
--- a/AudioPairing.tsx
+++ b/AudioPairing.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { playAudioData, listenForAudioData } from './audio';
 import { useRtcAndMesh } from './store';
 
@@ -11,9 +11,18 @@ export default function AudioPairing() {
     answerJson,
     status,
     log,
+    error,
+    clearError,
   } = useRtcAndMesh();
   const [listening, setListening] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (error) {
+      alert(error);
+      clearError();
+    }
+  }, [error, clearError]);
 
   async function listen(kind: 'offer' | 'answer') {
     abortRef.current?.abort();

--- a/QRPairing.tsx
+++ b/QRPairing.tsx
@@ -13,6 +13,8 @@ export default function QRPairing() {
     answerJson,
     status,
     log,
+    error,
+    clearError,
   } = useRtcAndMesh();
   const offerCanvasRef = useRef<HTMLCanvasElement>(null);
   const answerCanvasRef = useRef<HTMLCanvasElement>(null);
@@ -21,6 +23,13 @@ export default function QRPairing() {
   const abortRef = useRef<AbortController | null>(null);
   const [canReadClipboard, setCanReadClipboard] = useState(true);
   const [canWriteClipboard, setCanWriteClipboard] = useState(true);
+
+  useEffect(() => {
+    if (error) {
+      alert(error);
+      clearError();
+    }
+  }, [error, clearError]);
 
   useEffect(() => {
     if (offerJson && offerCanvasRef.current)

--- a/envelope.test.ts
+++ b/envelope.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { generateKeyPair, encryptEnvelope, decryptEnvelope } from './envelope';
+import {
+  generateKeyPair,
+  encryptEnvelope,
+  decryptEnvelope,
+  signData,
+  verifyData,
+} from './envelope';
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -62,5 +68,14 @@ describe('envelope', () => {
         alice.publicKey,
       ),
     ).rejects.toThrow();
+  });
+
+  it('signs and verifies data', async () => {
+    const { privateKey, publicKey } = await generateKeyPair();
+    const data = encoder.encode('auth-test');
+    const sig = await signData(data.buffer, privateKey);
+    expect(await verifyData(data.buffer, sig, publicKey)).toBe(true);
+    sig[0] ^= 0xff;
+    expect(await verifyData(data.buffer, sig, publicKey)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- add ECDSA signing/verification helpers to envelope utilities
- sign outbound public key messages and validate signatures when receiving keys
- surface public key signature errors in QR and audio pairing flows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b67b98c33883219221046eee536335