### PR TITLE
Add buffering and drain callbacks for RTC and WebSocket sessions

### DIFF
--- a/WebSocketSession.test.ts
+++ b/WebSocketSession.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { WebSocketSession } from './WebSocketSession';
+
+class MockWS {
+  public static OPEN = 1;
+  public readyState = MockWS.OPEN;
+  public bufferedAmount = 0;
+  public sent: any[] = [];
+  onopen?: () => void;
+  onclose?: (e: any) => void;
+  onerror?: (e: any) => void;
+  onmessage?: (e: any) => void;
+  constructor(public url: string) {}
+  send(data: any) {
+    this.sent.push(data);
+  }
+  close() {}
+}
+
+(globalThis as any).WebSocket = MockWS;
+
+describe('WebSocketSession buffering', () => {
+  it('queues when bufferedAmount high and drains on flush', () => {
+    vi.useFakeTimers();
+    const onDrain = vi.fn();
+    const s = new WebSocketSession({ url: 'ws://test', onDrain, maxBufferedAmount: 1, heartbeatMs: 10000 });
+    // @ts-ignore access private
+    const ws = (s as any).ws as MockWS;
+    ws.onopen?.();
+    ws.bufferedAmount = 2; // above threshold
+    s.send('a');
+    expect(ws.sent).toHaveLength(0);
+    // @ts-ignore access private
+    expect((s as any).outbox.length).toBe(1);
+    ws.bufferedAmount = 0; // buffer drained
+    vi.advanceTimersByTime(60); // allow flush interval
+    expect(ws.sent).toEqual(['a']);
+    expect(onDrain).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- queue RTC messages when `bufferedAmount` exceeds a threshold and fire `onDrain` once flushed
- support WebSocket buffering with periodic flushes and drain notifications
- add tests for RTC and WebSocket message buffering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b684cb80d08321a43d2db611532698