### PR TITLE
feat: log upload function and diagnostics feedback

### DIFF
--- a/Diagnostics.tsx
+++ b/Diagnostics.tsx
@@ -13,6 +13,7 @@ export default function Diagnostics() {
   }>({});
   const [showLogs, setShowLogs] = useState(false);
   const [uploading, setUploading] = useState(false);
+  const [uploadMessage, setUploadMessage] = useState<string | null>(null);
 
   const {
     stunUrl,
@@ -130,21 +131,30 @@ export default function Diagnostics() {
           {showLogs ? 'Hide Logs' : 'Show Logs'}
         </button>
         <button onClick={downloadLogs}>Download Logs</button>
-        <button
-          onClick={async () => {
-            setUploading(true);
-            try {
-              await uploadLogs();
-            } finally {
-              setUploading(false);
-            }
-          }}
-          disabled={uploading}
-        >
-          {uploading ? 'Uploading...' : 'Upload Logs'}
-        </button>
-      </div>
-      {showLogs && (
+          <button
+            onClick={async () => {
+              setUploading(true);
+              setUploadMessage(null);
+              try {
+                const ok = await uploadLogs();
+                setUploadMessage(ok ? 'Logs uploaded successfully' : 'Log upload failed');
+              } catch {
+                setUploadMessage('Log upload failed');
+              } finally {
+                setUploading(false);
+              }
+            }}
+            disabled={uploading}
+          >
+            {uploading ? 'Uploading...' : 'Upload Logs'}
+          </button>
+        </div>
+        {uploadMessage && (
+          <p className="small" style={{ marginTop: 4 }}>
+            {uploadMessage}
+          </p>
+        )}
+        {showLogs && (
         <pre
           className="small"
           style={{ maxHeight: 200, overflow: 'auto', marginTop: 12 }}

--- a/logger.ts
+++ b/logger.ts
@@ -41,7 +41,9 @@ export function downloadLogs() {
 
 export async function uploadLogs(url?: string) {
   const target =
-    url || (import.meta as any).env?.VITE_LOG_UPLOAD_URL || '/logs';
+    url ||
+    (import.meta as any).env?.VITE_LOG_UPLOAD_URL ||
+    '/.netlify/functions/logs';
   try {
     const body = getLogLines().join('\n');
     const res = await fetch(target, {

--- a/netlify/functions/logs.js
+++ b/netlify/functions/logs.js
@@ -1,14 +1,21 @@
+const fs = require('fs/promises');
+
+// Simple Netlify function that stores POSTed log data on the temp filesystem.
+// In a real deployment this could forward the logs to an external service or
+// email address instead.
 exports.handler = async function (event) {
   if (event.httpMethod !== 'POST') {
     return { statusCode: 405, body: 'Method Not Allowed' };
   }
   try {
-    // Simply log the first part of the body; a real implementation could
-    // persist this to storage or forward to a logging service.
-    const snippet = (event.body || '').slice(0, 1000);
-    console.log('Received logs', snippet);
+    const body = event.body || '';
+    // Write the body to a temporary file so it can be inspected later.
+    const file = `/tmp/log-${Date.now()}.txt`;
+    await fs.writeFile(file, body, 'utf8');
+    console.log('Stored logs at', file);
     return { statusCode: 200, body: 'ok' };
   } catch (err) {
+    console.error('Failed to store logs', err);
     return { statusCode: 500, body: String(err) };
   }
 };


### PR DESCRIPTION
## Summary
- store POSTed logs in Netlify temp directory via new serverless function
- default log uploader to call the Netlify logs function
- show upload success or failure in Diagnostics panel

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6a220364c83219b6259cc54c9bc3b