### PR TITLE
chore: clear deprecated proxy env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      http_proxy: ""
+      https_proxy: ""
+      HTTP_PROXY: ""
+      HTTPS_PROXY: ""
+      npm_config_http_proxy: ""
+      npm_config_https_proxy: ""
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,13 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    env:
+      http_proxy: ""
+      https_proxy: ""
+      HTTP_PROXY: ""
+      HTTPS_PROXY: ""
+      npm_config_http_proxy: ""
+      npm_config_https_proxy: ""
     steps:
       - uses: actions/checkout@v4
         with:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sovereign Voice Mesh — v0.0.17 (Flattened)
+# Sovereign Voice Mesh — v0.0.18 (Flattened)
 
 All files are in the repo root for phone-friendly GitHub upload. Netlify-ready.
 
@@ -13,6 +13,17 @@ npm run dev
 
 ```bash
 npm run build
+```
+
+## Troubleshooting
+
+If you see `npm warn Unknown env config "http-proxy"`, deprecated proxy
+environment variables are set. Clear them (or switch to `HTTP_PROXY`/`HTTPS_PROXY`
+and `NPM_CONFIG_PROXY`/`NPM_CONFIG_HTTPS_PROXY`) before running npm commands:
+
+```bash
+unset http_proxy https_proxy npm_config_http_proxy npm_config_https_proxy
+npm test
 ```
 
 ## Configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sovereign-voice-mesh",
-  "version": "0.0.16",
+  "version": "0.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sovereign-voice-mesh",
-      "version": "0.0.16",
+      "version": "0.0.18",
       "dependencies": {
         "@xenova/transformers": "^2.10.1",
         "jsqr": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sovereign-voice-mesh",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- clear deprecated proxy env vars in CI and lint workflows
- document how to clear npm proxy variables locally
- bump package version to 0.0.18

## Testing
- `npm_config_http_proxy= npm_config_https_proxy= npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b688d716c08321ad340cf1a00f1cd1