### PR TITLE
Calibrate audio speed with adaptive sample test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      http_proxy: ""
-      https_proxy: ""
-      HTTP_PROXY: ""
-      HTTPS_PROXY: ""
-      npm_config_http_proxy: ""
-      npm_config_https_proxy: ""
+      http_proxy: ''
+      https_proxy: ''
+      HTTP_PROXY: ''
+      HTTPS_PROXY: ''
+      npm_config_http_proxy: ''
+      npm_config_https_proxy: ''
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,12 +8,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     env:
-      http_proxy: ""
-      https_proxy: ""
-      HTTP_PROXY: ""
-      HTTPS_PROXY: ""
-      npm_config_http_proxy: ""
-      npm_config_https_proxy: ""
+      http_proxy: ''
+      https_proxy: ''
+      HTTP_PROXY: ''
+      HTTPS_PROXY: ''
+      npm_config_http_proxy: ''
+      npm_config_https_proxy: ''
     steps:
       - uses: actions/checkout@v4
         with:

--- a/AudioPairing.tsx
+++ b/AudioPairing.tsx
@@ -1,5 +1,12 @@
 import { useRef, useState } from 'react';
-import { playAudioData, listenForAudioData } from './audio';
+import {
+  playAudioData,
+  listenForAudioData,
+  estimateAudioDuration,
+  playCalibrationSamples,
+  calibrateBitDuration,
+  BIT_DURATION,
+} from './audio';
 import { useRtcAndMesh } from './store';
 import { useToast } from './Toast';
 
@@ -16,18 +23,53 @@ export default function AudioPairing() {
   const [listening, setListening] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
   const toast = useToast();
+  const [progress, setProgress] = useState(0);
+  const progressTimer = useRef<number | null>(null);
+  const progressDuration = useRef(0);
+  const [bitDuration, setBitDuration] = useState(BIT_DURATION);
+
+  function startProgress(duration: number) {
+    progressDuration.current = duration;
+    setProgress(0);
+    progressTimer.current && clearInterval(progressTimer.current);
+    const start = performance.now();
+    progressTimer.current = window.setInterval(() => {
+      const elapsed = (performance.now() - start) / 1000;
+      const p = Math.min(elapsed / duration, 1);
+      setProgress(p);
+      if (p >= 1) {
+        stopProgress();
+      }
+    }, 100);
+  }
+
+  function stopProgress() {
+    if (progressTimer.current !== null) {
+      clearInterval(progressTimer.current);
+      progressTimer.current = null;
+    }
+    setProgress(0);
+  }
 
   async function listen(kind: 'offer' | 'answer') {
     abortRef.current?.abort();
     abortRef.current = new AbortController();
     setListening(true);
+    startProgress(15); // default timeout for listening
     try {
-      const data = await listenForAudioData(abortRef.current.signal);
+      const d = await calibrateBitDuration(abortRef.current.signal);
+      setBitDuration(d);
+      const data = await listenForAudioData(
+        abortRef.current.signal,
+        undefined,
+        d,
+      );
       if (kind === 'offer') await acceptOfferAndCreateAnswer(data);
       else await acceptAnswer(data);
     } catch (e) {
       toast(String((e as any)?.message || e));
     } finally {
+      stopProgress();
       setListening(false);
     }
   }
@@ -40,7 +82,13 @@ export default function AudioPairing() {
           <button
             onClick={async () => {
               await createOffer();
-              if (offerJson) await playAudioData(offerJson);
+              if (offerJson) {
+                await playCalibrationSamples();
+                await new Promise((r) => setTimeout(r, 500));
+                startProgress(estimateAudioDuration(offerJson, bitDuration));
+                await playAudioData(offerJson, bitDuration);
+                stopProgress();
+              }
             }}
             title="Create offer and play audio"
           >
@@ -68,7 +116,13 @@ export default function AudioPairing() {
           </button>
           <button
             onClick={async () => {
-              if (answerJson) await playAudioData(answerJson);
+              if (answerJson) {
+                await playCalibrationSamples();
+                await new Promise((r) => setTimeout(r, 500));
+                startProgress(estimateAudioDuration(answerJson, bitDuration));
+                await playAudioData(answerJson, bitDuration);
+                stopProgress();
+              }
             }}
             data-inert={!answerJson}
             title={answerJson ? 'Play answer audio' : 'No answer yet'}
@@ -83,6 +137,18 @@ export default function AudioPairing() {
         <p>
           <b>{status}</b>
         </p>
+        <p className="small">Bit duration: {bitDuration.toFixed(3)}s</p>
+        {progressTimer.current !== null && (
+          <div>
+            <progress value={progress} max={1} style={{ width: '100%' }} />
+            <p className="small">
+              {Math.max(0, progressDuration.current * (1 - progress)).toFixed(
+                1,
+              )}{' '}
+              s remaining
+            </p>
+          </div>
+        )}
         {listening && (
           <button
             onClick={() => {

--- a/Diagnostics.tsx
+++ b/Diagnostics.tsx
@@ -131,30 +131,32 @@ export default function Diagnostics() {
           {showLogs ? 'Hide Logs' : 'Show Logs'}
         </button>
         <button onClick={downloadLogs}>Download Logs</button>
-          <button
-            onClick={async () => {
-              setUploading(true);
-              setUploadMessage(null);
-              try {
-                const ok = await uploadLogs();
-                setUploadMessage(ok ? 'Logs uploaded successfully' : 'Log upload failed');
-              } catch {
-                setUploadMessage('Log upload failed');
-              } finally {
-                setUploading(false);
-              }
-            }}
-            disabled={uploading}
-          >
-            {uploading ? 'Uploading...' : 'Upload Logs'}
-          </button>
-        </div>
-        {uploadMessage && (
-          <p className="small" style={{ marginTop: 4 }}>
-            {uploadMessage}
-          </p>
-        )}
-        {showLogs && (
+        <button
+          onClick={async () => {
+            setUploading(true);
+            setUploadMessage(null);
+            try {
+              const ok = await uploadLogs();
+              setUploadMessage(
+                ok ? 'Logs uploaded successfully' : 'Log upload failed',
+              );
+            } catch {
+              setUploadMessage('Log upload failed');
+            } finally {
+              setUploading(false);
+            }
+          }}
+          disabled={uploading}
+        >
+          {uploading ? 'Uploading...' : 'Upload Logs'}
+        </button>
+      </div>
+      {uploadMessage && (
+        <p className="small" style={{ marginTop: 4 }}>
+          {uploadMessage}
+        </p>
+      )}
+      {showLogs && (
         <pre
           className="small"
           style={{ maxHeight: 200, overflow: 'auto', marginTop: 12 }}

--- a/Mesh.ts
+++ b/Mesh.ts
@@ -90,7 +90,10 @@ export class MeshRouter extends EventTarget {
   // Track when each message id was seen so old ids can be purged
   private seen: Map<string, number> = new Map();
   private readonly seenTtlMs = 5 * 60 * 1000; // 5 minutes
-  constructor(public readonly selfId: string, private adapter?: MeshSeenAdapter) {
+  constructor(
+    public readonly selfId: string,
+    private adapter?: MeshSeenAdapter,
+  ) {
     super();
     this.adapter?.load().then((entries) => {
       for (const [id, ts] of Object.entries(entries)) this.seen.set(id, ts);

--- a/Toast.tsx
+++ b/Toast.tsx
@@ -1,4 +1,10 @@
-import { createContext, ReactNode, useCallback, useContext, useState } from 'react';
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useState,
+} from 'react';
 
 const ToastContext = createContext<(msg: string) => void>(() => {
   throw new Error('ToastProvider missing');

--- a/WebSocketSession.test.ts
+++ b/WebSocketSession.test.ts
@@ -23,7 +23,12 @@ describe('WebSocketSession buffering', () => {
   it('queues when bufferedAmount high and drains on flush', () => {
     vi.useFakeTimers();
     const onDrain = vi.fn();
-    const s = new WebSocketSession({ url: 'ws://test', onDrain, maxBufferedAmount: 1, heartbeatMs: 10000 });
+    const s = new WebSocketSession({
+      url: 'ws://test',
+      onDrain,
+      maxBufferedAmount: 1,
+      heartbeatMs: 10000,
+    });
     // @ts-ignore access private
     const ws = (s as any).ws as MockWS;
     ws.onopen?.();

--- a/file-transfer.test.ts
+++ b/file-transfer.test.ts
@@ -10,7 +10,10 @@ async function sendFileThroughMesh(
   const chunkSize = 16 * 1024;
   const total = Math.ceil(file.size / chunkSize);
   for (let i = 0; i < total; i++) {
-    const slice = file.slice(i * chunkSize, Math.min(file.size, (i + 1) * chunkSize));
+    const slice = file.slice(
+      i * chunkSize,
+      Math.min(file.size, (i + 1) * chunkSize),
+    );
     const buf = await slice.arrayBuffer();
     const payload: FileChunkPayload = {
       name: file.name,
@@ -20,7 +23,12 @@ async function sendFileThroughMesh(
       total,
       data: Array.from(new Uint8Array(buf)),
     };
-    sender.send({ id: crypto.randomUUID(), ttl: 1, type: 'file', payload } as Message);
+    sender.send({
+      id: crypto.randomUUID(),
+      ttl: 1,
+      type: 'file',
+      payload,
+    } as Message);
   }
 }
 

--- a/store.test.ts
+++ b/store.test.ts
@@ -11,7 +11,11 @@ describe('pubkey verification', () => {
     const sigKey = await exportPublicKeyJwk(kp.ecdsa.publicKey);
     const data = encoder.encode(JSON.stringify(jwk));
     const sigBuf = await sign(data.buffer, kp.ecdsa.privateKey);
-    const payload = { key: jwk, sig: Array.from(new Uint8Array(sigBuf)), sigKey };
+    const payload = {
+      key: jwk,
+      sig: Array.from(new Uint8Array(sigBuf)),
+      sigKey,
+    };
     const pub = await verifyAndImportPubKey(payload);
     expect(pub.type).toBe('public');
   });
@@ -28,4 +32,3 @@ describe('pubkey verification', () => {
     await expect(verifyAndImportPubKey(payload)).rejects.toThrow();
   });
 });
-

--- a/store.ts
+++ b/store.ts
@@ -48,9 +48,16 @@ export function useRtcAndMesh() {
   const [logLines, setLogLines] = useState<string[]>([]);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [rtt, setRtt] = useState(0);
-  const [rtcStats, setRtcStats] = useState<{ rtt?: number; ice?: string; dc?: string }>({});
-  const [wsStats, setWsStats] =
-    useState<{ rtt?: number; ice?: string; dc?: string }>({});
+  const [rtcStats, setRtcStats] = useState<{
+    rtt?: number;
+    ice?: string;
+    dc?: string;
+  }>({});
+  const [wsStats, setWsStats] = useState<{
+    rtt?: number;
+    ice?: string;
+    dc?: string;
+  }>({});
   const [netInfo, setNetInfo] = useState<{
     type?: string;
     effectiveType?: string;
@@ -131,7 +138,10 @@ export function useRtcAndMesh() {
       const ecdhPub = await exportPublicKeyJwk(k.ecdh.publicKey);
       const ecdhPriv = await crypto.subtle.exportKey('jwk', k.ecdh.privateKey);
       const ecdsaPub = await exportPublicKeyJwk(k.ecdsa.publicKey);
-      const ecdsaPriv = await crypto.subtle.exportKey('jwk', k.ecdsa.privateKey);
+      const ecdsaPriv = await crypto.subtle.exportKey(
+        'jwk',
+        k.ecdsa.privateKey,
+      );
       const payload = {
         ecdh: { pub: ecdhPub, priv: ecdhPriv },
         ecdsa: { pub: ecdsaPub, priv: ecdsaPriv },
@@ -208,7 +218,9 @@ export function useRtcAndMesh() {
     () =>
       new MeshRouter(
         crypto.randomUUID(),
-        typeof indexedDB !== 'undefined' ? new IndexedDbSeenAdapter() : undefined,
+        typeof indexedDB !== 'undefined'
+          ? new IndexedDbSeenAdapter()
+          : undefined,
       ),
     [],
   );
@@ -507,8 +519,10 @@ export function useRtcAndMesh() {
     const chunkSize = 16 * 1024; // 16KB chunks
     const total = Math.ceil(file.size / chunkSize);
     for (let i = 0; i < total; i++) {
-      const slice = file
-        .slice(i * chunkSize, Math.min(file.size, (i + 1) * chunkSize));
+      const slice = file.slice(
+        i * chunkSize,
+        Math.min(file.size, (i + 1) * chunkSize),
+      );
       const buf = await slice.arrayBuffer();
       const payload = {
         name: file.name,


### PR DESCRIPTION
## Summary
- Probe audio bit rates by playing a fast-to-slow calibration sample and detecting the first decodable rate
- Apply the detected bit duration to offer/answer playback and show it in the status panel
- Format repository to satisfy Prettier

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68b7889872d48321a3ca1fddd948dabe