### PR TITLE
Add ECDSA-signed key exchange and surface verification errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      http_proxy: ''
+      https_proxy: ''
+      HTTP_PROXY: ''
+      HTTPS_PROXY: ''
+      npm_config_http_proxy: ''
+      npm_config_https_proxy: ''
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,13 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    env:
+      http_proxy: ''
+      https_proxy: ''
+      HTTP_PROXY: ''
+      HTTPS_PROXY: ''
+      npm_config_http_proxy: ''
+      npm_config_https_proxy: ''
     steps:
       - uses: actions/checkout@v4
         with:

--- a/App.tsx
+++ b/App.tsx
@@ -4,17 +4,19 @@ import AudioPairing from './AudioPairing';
 import Chat from './Chat';
 import VoicePanel from './VoicePanel';
 import Diagnostics from './Diagnostics';
+import FileTransfer from './FileTransfer';
 const version = import.meta.env.VITE_APP_VERSION;
 
 export default function App() {
   const [tab, setTab] = useState<
-    'connect' | 'audio' | 'voice' | 'chat' | 'diagnostics'
+    'connect' | 'audio' | 'voice' | 'chat' | 'files' | 'diagnostics'
   >('connect');
   const tabs = [
     { key: 'connect', label: 'QR Connect' },
     { key: 'audio', label: 'Audio Connect' },
     { key: 'voice', label: 'Voice' },
     { key: 'chat', label: 'Chat' },
+    { key: 'files', label: 'Files' },
     { key: 'diagnostics', label: 'Diagnostics' },
   ] as const;
   return (
@@ -36,6 +38,7 @@ export default function App() {
       {tab === 'audio' && <AudioPairing />}
       {tab === 'voice' && <VoicePanel />}
       {tab === 'chat' && <Chat />}
+      {tab === 'files' && <FileTransfer />}
       {tab === 'diagnostics' && <Diagnostics />}
       <hr />
       <p className="small">

--- a/AudioPairing.tsx
+++ b/AudioPairing.tsx
@@ -1,6 +1,14 @@
-import { useRef, useState } from 'react';
-import { playAudioData, listenForAudioData } from './audio';
+import { useEffect, useRef, useState } from 'react';
+import {
+  playAudioData,
+  listenForAudioData,
+  estimateAudioDuration,
+  playCalibrationSamples,
+  calibrateBitDuration,
+  BIT_DURATION,
+} from './audio';
 import { useRtcAndMesh } from './store';
+import { useToast } from './Toast';
 
 export default function AudioPairing() {
   const {
@@ -11,21 +19,65 @@ export default function AudioPairing() {
     answerJson,
     status,
     log,
+    error,
+    clearError,
   } = useRtcAndMesh();
   const [listening, setListening] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
+  const toast = useToast();
+  useEffect(() => {
+    if (error) {
+      toast(error);
+      clearError();
+    }
+  }, [error, clearError, toast]);
+  const [progress, setProgress] = useState(0);
+  const progressTimer = useRef<number | null>(null);
+  const progressDuration = useRef(0);
+  const [bitDuration, setBitDuration] = useState(BIT_DURATION);
+
+  function startProgress(duration: number) {
+    progressDuration.current = duration;
+    setProgress(0);
+    progressTimer.current && clearInterval(progressTimer.current);
+    const start = performance.now();
+    progressTimer.current = window.setInterval(() => {
+      const elapsed = (performance.now() - start) / 1000;
+      const p = Math.min(elapsed / duration, 1);
+      setProgress(p);
+      if (p >= 1) {
+        stopProgress();
+      }
+    }, 100);
+  }
+
+  function stopProgress() {
+    if (progressTimer.current !== null) {
+      clearInterval(progressTimer.current);
+      progressTimer.current = null;
+    }
+    setProgress(0);
+  }
 
   async function listen(kind: 'offer' | 'answer') {
     abortRef.current?.abort();
     abortRef.current = new AbortController();
     setListening(true);
+    startProgress(15); // default timeout for listening
     try {
-      const data = await listenForAudioData(abortRef.current.signal);
+      const d = await calibrateBitDuration(abortRef.current.signal);
+      setBitDuration(d);
+      const data = await listenForAudioData(
+        abortRef.current.signal,
+        undefined,
+        d,
+      );
       if (kind === 'offer') await acceptOfferAndCreateAnswer(data);
       else await acceptAnswer(data);
     } catch (e) {
-      alert(String((e as any)?.message || e));
+      toast(String((e as any)?.message || e));
     } finally {
+      stopProgress();
       setListening(false);
     }
   }
@@ -38,7 +90,13 @@ export default function AudioPairing() {
           <button
             onClick={async () => {
               await createOffer();
-              if (offerJson) await playAudioData(offerJson);
+              if (offerJson) {
+                await playCalibrationSamples();
+                await new Promise((r) => setTimeout(r, 500));
+                startProgress(estimateAudioDuration(offerJson, bitDuration));
+                await playAudioData(offerJson, bitDuration);
+                stopProgress();
+              }
             }}
             title="Create offer and play audio"
           >
@@ -66,7 +124,13 @@ export default function AudioPairing() {
           </button>
           <button
             onClick={async () => {
-              if (answerJson) await playAudioData(answerJson);
+              if (answerJson) {
+                await playCalibrationSamples();
+                await new Promise((r) => setTimeout(r, 500));
+                startProgress(estimateAudioDuration(answerJson, bitDuration));
+                await playAudioData(answerJson, bitDuration);
+                stopProgress();
+              }
             }}
             data-inert={!answerJson}
             title={answerJson ? 'Play answer audio' : 'No answer yet'}
@@ -81,6 +145,18 @@ export default function AudioPairing() {
         <p>
           <b>{status}</b>
         </p>
+        <p className="small">Bit duration: {bitDuration.toFixed(3)}s</p>
+        {progressTimer.current !== null && (
+          <div>
+            <progress value={progress} max={1} style={{ width: '100%' }} />
+            <p className="small">
+              {Math.max(0, progressDuration.current * (1 - progress)).toFixed(
+                1,
+              )}{' '}
+              s remaining
+            </p>
+          </div>
+        )}
         {listening && (
           <button
             onClick={() => {
@@ -103,3 +179,4 @@ export default function AudioPairing() {
     </div>
   );
 }
+

--- a/FileTransfer.tsx
+++ b/FileTransfer.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { useRtcAndMesh } from './store';
+import { useToast } from './Toast';
+
+export default function FileTransfer() {
+  const { sendFile, status } = useRtcAndMesh();
+  const [file, setFile] = useState<File | null>(null);
+  const [progress, setProgress] = useState(0);
+  const toast = useToast();
+
+  async function onSend() {
+    if (!file) {
+      toast('Select a file');
+      return;
+    }
+    setProgress(0);
+    await sendFile(file, (sent, total) => {
+      setProgress(Math.round((sent / total) * 100));
+    });
+  }
+
+  return (
+    <div className="card">
+      <h2>File Transfer</h2>
+      {status !== 'connected' && <div className="small">Status: {status}</div>}
+      <div className="row" style={{ alignItems: 'center', gap: 8 }}>
+        <input
+          type="file"
+          onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
+          aria-label="Select file"
+        />
+        <button onClick={onSend} data-inert={!file} aria-label="Send file">
+          Send
+        </button>
+      </div>
+      {progress > 0 && (
+        <div className="small" style={{ marginTop: 8 }}>
+          Progress: {progress}%
+        </div>
+      )}
+    </div>
+  );
+}

--- a/Mesh.ts
+++ b/Mesh.ts
@@ -1,9 +1,18 @@
+export type FileChunkPayload = {
+  name: string;
+  type: string;
+  size: number;
+  chunk: number;
+  total: number;
+  data: number[];
+};
+
 export type Message = {
   id: string;
   ttl: number;
   from: string;
   type: string;
-  payload: any;
+  payload: any | FileChunkPayload;
   timestamp?: number;
   enc?: boolean;
 };
@@ -13,14 +22,82 @@ import { log } from './logger';
 /**
  * Simple in-memory mesh relay with TTL and dedupe.
  */
+export interface MeshSeenAdapter {
+  load(): Promise<Record<string, number>>;
+  save(id: string, ts: number): Promise<void>;
+  prune(expireBefore: number): Promise<void>;
+}
+
+export class IndexedDbSeenAdapter implements MeshSeenAdapter {
+  private db: Promise<IDBDatabase>;
+  private store = 'seen';
+  constructor(dbName = 'mesh-router') {
+    this.db = new Promise((resolve, reject) => {
+      const req = indexedDB.open(dbName, 1);
+      req.onupgradeneeded = () => req.result.createObjectStore(this.store);
+      req.onerror = () => reject(req.error!);
+      req.onsuccess = () => resolve(req.result);
+    });
+  }
+  async load() {
+    const db = await this.db;
+    return new Promise<Record<string, number>>((res, rej) => {
+      const tx = db.transaction(this.store, 'readonly');
+      const store = tx.objectStore(this.store);
+      const out: Record<string, number> = {};
+      const req = store.openCursor();
+      req.onerror = () => rej(req.error!);
+      req.onsuccess = () => {
+        const cur = req.result;
+        if (cur) {
+          out[cur.key as string] = cur.value as number;
+          cur.continue();
+        } else res(out);
+      };
+    });
+  }
+  async save(id: string, ts: number) {
+    const db = await this.db;
+    return new Promise<void>((res, rej) => {
+      const tx = db.transaction(this.store, 'readwrite');
+      tx.objectStore(this.store).put(ts, id);
+      tx.oncomplete = () => res();
+      tx.onerror = () => rej(tx.error!);
+    });
+  }
+  async prune(expireBefore: number) {
+    const db = await this.db;
+    return new Promise<void>((res, rej) => {
+      const tx = db.transaction(this.store, 'readwrite');
+      const store = tx.objectStore(this.store);
+      const req = store.openCursor();
+      req.onerror = () => rej(req.error!);
+      req.onsuccess = () => {
+        const cur = req.result;
+        if (cur) {
+          if ((cur.value as number) < expireBefore) store.delete(cur.key);
+          cur.continue();
+        }
+      };
+      tx.oncomplete = () => res();
+    });
+  }
+}
+
 export class MeshRouter extends EventTarget {
   private peers: Map<string, (msg: Message) => void> = new Map();
   private local: Set<string> = new Set();
   // Track when each message id was seen so old ids can be purged
   private seen: Map<string, number> = new Map();
   private readonly seenTtlMs = 5 * 60 * 1000; // 5 minutes
-  constructor(public readonly selfId: string) {
+  constructor(
+    public readonly selfId: string,
+    private adapter?: MeshSeenAdapter,
+  ) {
     super();
+    this.adapter?.load().then((entries) => {
+      for (const [id, ts] of Object.entries(entries)) this.seen.set(id, ts);
+    });
   }
 
   connectPeer(
@@ -49,6 +126,7 @@ export class MeshRouter extends EventTarget {
     for (const [id, ts] of this.seen) {
       if (now - ts > this.seenTtlMs) this.seen.delete(id);
     }
+    this.adapter?.prune(now - this.seenTtlMs).catch(() => {});
   }
 
   private deliver(msg: Message) {
@@ -56,6 +134,7 @@ export class MeshRouter extends EventTarget {
     this.pruneSeen(now);
     if (msg.ttl < 0 || this.seen.has(msg.id)) return;
     this.seen.set(msg.id, now);
+    this.adapter?.save(msg.id, now).catch(() => {});
     for (const [id, h] of this.peers) {
       if (id === msg.from) continue; // no immediate echo back to sender id
 

--- a/QRPairing.tsx
+++ b/QRPairing.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { renderQR, scanQRFromVideo, startVideo } from './qr';
 import { useRtcAndMesh } from './store';
+import { useToast } from './Toast';
 
 export default function QRPairing() {
   const {
@@ -13,6 +14,8 @@ export default function QRPairing() {
     answerJson,
     status,
     log,
+    error,
+    clearError,
   } = useRtcAndMesh();
   const offerCanvasRef = useRef<HTMLCanvasElement>(null);
   const answerCanvasRef = useRef<HTMLCanvasElement>(null);
@@ -21,6 +24,13 @@ export default function QRPairing() {
   const abortRef = useRef<AbortController | null>(null);
   const [canReadClipboard, setCanReadClipboard] = useState(true);
   const [canWriteClipboard, setCanWriteClipboard] = useState(true);
+  const toast = useToast();
+  useEffect(() => {
+    if (error) {
+      toast(error);
+      clearError();
+    }
+  }, [error, clearError, toast]);
 
   useEffect(() => {
     if (offerJson && offerCanvasRef.current)
@@ -35,7 +45,7 @@ export default function QRPairing() {
     try {
       await createOffer();
     } catch (e) {
-      alert(String((e as any)?.message || e));
+      toast(String((e as any)?.message || e));
     }
   }
   async function scanAndAcceptOffer() {
@@ -58,7 +68,7 @@ export default function QRPairing() {
       }
       await acceptOfferAndCreateAnswer(data);
     } catch (e) {
-      alert(String((e as any)?.message || e));
+      toast(String((e as any)?.message || e));
     } finally {
       if (stream) {
         stream.getTracks().forEach((t) => t.stop());
@@ -78,14 +88,14 @@ export default function QRPairing() {
           name: 'clipboard-read',
         });
         if (readPerm.state === 'denied') {
-          alert('Clipboard read permission denied. Paste disabled.');
+          toast('Clipboard read permission denied. Paste disabled.');
           setCanReadClipboard(false);
         }
         readPerm.onchange = () => {
           const allowed = readPerm.state !== 'denied';
           setCanReadClipboard(allowed);
           if (!allowed)
-            alert('Clipboard read permission denied. Paste disabled.');
+            toast('Clipboard read permission denied. Paste disabled.');
         };
       } catch {}
       try {
@@ -93,14 +103,14 @@ export default function QRPairing() {
           name: 'clipboard-write',
         });
         if (writePerm.state === 'denied') {
-          alert('Clipboard write permission denied. Copy disabled.');
+          toast('Clipboard write permission denied. Copy disabled.');
           setCanWriteClipboard(false);
         }
         writePerm.onchange = () => {
           const allowed = writePerm.state !== 'denied';
           setCanWriteClipboard(allowed);
           if (!allowed)
-            alert('Clipboard write permission denied. Copy disabled.');
+            toast('Clipboard write permission denied. Copy disabled.');
         };
       } catch {}
     }
@@ -126,7 +136,7 @@ export default function QRPairing() {
       }
       await acceptAnswer(data);
     } catch (e) {
-      alert(String((e as any)?.message || e));
+      toast(String((e as any)?.message || e));
     } finally {
       if (stream) {
         stream.getTracks().forEach((t) => t.stop());
@@ -270,11 +280,12 @@ function PasteArea({
   canReadClipboard: boolean;
 }) {
   const [val, setVal] = useState('');
+  const toast = useToast();
   async function handle() {
     try {
       JSON.parse(val);
     } catch {
-      alert('Not valid JSON');
+      toast('Not valid JSON');
       return;
     }
     await onPasteJSON(val);
@@ -300,7 +311,7 @@ function PasteArea({
               const t = await navigator.clipboard.readText();
               setVal(t);
             } catch (e) {
-              alert('Clipboard not accessible');
+              toast('Clipboard not accessible');
             }
           }}
           title={

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sovereign Voice Mesh — v0.0.8 (Flattened)
+# Sovereign Voice Mesh — v0.0.21 (Flattened)
 
 All files are in the repo root for phone-friendly GitHub upload. Netlify-ready.
 
@@ -15,6 +15,24 @@ npm run dev
 npm run build
 ```
 
+## Troubleshooting
+
+If you see `npm warn Unknown env config "http-proxy"`, deprecated proxy
+environment variables are set. Clear them (or switch to `HTTP_PROXY`/`HTTPS_PROXY`
+and `NPM_CONFIG_PROXY`/`NPM_CONFIG_HTTPS_PROXY`) before running npm commands:
+
+```bash
+unset http_proxy https_proxy npm_config_http_proxy npm_config_https_proxy
+npm test
+```
+
+## Configuration
+
+- STUN/TURN servers can be set from the in-app **Diagnostics** page. The URLs
+  are saved to local storage and used when establishing new WebRTC sessions.
+- The WebSocket fallback server is configured via the `VITE_WS_URL`
+  environment variable.
+
 ## Versioning
 
 Every pull request must bump the `version` field in `package.json`. CI runs
@@ -26,6 +44,7 @@ commit.
 - `RtcSession.ts` – handles WebRTC data channel setup and messaging between peers.
 - `Mesh.ts` – provides an in-memory relay that forwards and deduplicates messages with TTL control.
 - `WebSocketSession.ts` – fallback transport with heartbeat and reconnection when WebRTC fails.
+- `envelope.ts` – cryptographic utilities for ECDH/AES-GCM and ECDSA signatures.
 - `Diagnostics.tsx` – displays network information and service-worker status.
 - `VoicePanel.tsx` – React component for managing local speech-to-text sessions and displaying transcripts.
 - `sw.js` – service worker implementing a network-first cache to keep the app functional offline.
@@ -34,6 +53,8 @@ commit.
 ## Security
 
 - React escapes message content when rendering to prevent cross-site scripting (XSS). Messages are stored and transmitted as raw text.
+- Public keys are signed and verified with ECDSA so peers are authenticated before encrypted messages are exchanged.
+- Pairing interfaces toast verification failures so users see when a remote key's signature is invalid.
 
 ## Whisper WASM models
 

--- a/RtcSession.ts
+++ b/RtcSession.ts
@@ -11,12 +11,17 @@ export type RtcEvents = {
     dc?: string;
     rtt?: number;
   }) => void;
+  /** Called when buffered messages have been sent */
+  onDrain?: () => void;
 };
 
 export type RtcOptions = RtcEvents & {
-  useStun?: boolean; // default false for offline-respecting
+  /** Optional ICE server configuration */
+  iceServers?: RTCIceServer[];
   heartbeatMs?: number;
   signal?: AbortSignal;
+  /** Maximum DataChannel bufferedAmount before queuing */
+  maxBufferedAmount?: number;
 };
 
 export class RtcSession {
@@ -24,15 +29,19 @@ export class RtcSession {
   private pc: RTCPeerConnection;
   private dc?: RTCDataChannel;
   private hb: Heartbeat;
-  private useStun: boolean;
+  private iceServers: RTCIceServer[];
   private abortSignal?: AbortSignal;
   private abortHandler?: () => void;
+  private outbox: (string | ArrayBuffer | ArrayBufferView)[] = [];
+  private readonly maxOutboxSize = 100;
+  private readonly maxBufferedAmount: number;
 
   constructor(opts: RtcOptions = {}) {
     this.events = opts;
-    this.useStun = !!opts.useStun;
+    this.iceServers = opts.iceServers ?? [];
     const interval = opts.heartbeatMs ?? 5000;
-    log('rtc', 'RtcSession created useStun=' + this.useStun);
+    this.maxBufferedAmount = opts.maxBufferedAmount ?? 64 * 1024;
+    log('rtc', 'RtcSession created iceServers=' + this.iceServers.length);
     this.pc = this.initPc();
     this.hb = new Heartbeat({
       intervalMs: interval,
@@ -64,10 +73,7 @@ export class RtcSession {
   // Create a new RTCPeerConnection and wire up all of our event handlers.
   // This allows the session to be reused after being closed.
   private initPc(): RTCPeerConnection {
-    const iceServers = this.useStun
-      ? [{ urls: 'stun:stun.l.google.com:19302' }]
-      : [];
-    const pc = new RTCPeerConnection({ iceServers });
+    const pc = new RTCPeerConnection({ iceServers: this.iceServers });
 
     pc.oniceconnectionstatechange = () => {
       log('rtc', 'iceConnectionState:' + pc.iceConnectionState);
@@ -115,6 +121,7 @@ export class RtcSession {
       log('rtc', 'dc open');
       this.hb.start();
       this.events.onOpen?.();
+      this.flushOutbox();
     };
     dc.onclose = () => {
       log('rtc', 'dc close');
@@ -135,6 +142,8 @@ export class RtcSession {
       if (this.hb.handle(data)) return;
       this.events.onMessage?.(data);
     };
+    dc.bufferedAmountLowThreshold = this.maxBufferedAmount;
+    dc.onbufferedamountlow = () => this.flushOutbox();
   }
 
   async createOffer(): Promise<string> {
@@ -185,12 +194,26 @@ export class RtcSession {
       throw new Error('DataChannel not open');
     }
     log('rtc', 'send:' + (typeof data === 'string' ? data : '[binary]'));
+    if (
+      this.dc.bufferedAmount >= this.maxBufferedAmount ||
+      this.outbox.length > 0
+    ) {
+      this.outbox.push(data);
+      if (this.outbox.length > this.maxOutboxSize) {
+        const drop = this.outbox.length - this.maxOutboxSize;
+        this.outbox.splice(0, drop);
+        log('rtc', 'drop queued:' + drop);
+      }
+      this.flushOutbox();
+      return;
+    }
     if (typeof data === 'string') {
       this.dc.send(data);
+    } else if (data instanceof ArrayBuffer) {
+      // Send ArrayBuffer directly to avoid extra copies
+      this.dc.send(data);
     } else {
-      const buf = data instanceof ArrayBuffer ? new Uint8Array(data) : data;
-      // Cast to satisfy the overloaded RTCDataChannel.send signature
-      this.dc.send(buf as any);
+      this.dc.send(data as any);
     }
   }
 
@@ -229,7 +252,27 @@ export class RtcSession {
   }
 
   getStats() {
-    return { rtt: this.hb.rtt };
+    return {
+      rtt: this.hb.rtt,
+      ice: this.pc.iceConnectionState,
+      dc: this.dc?.readyState,
+    };
+  }
+
+  private flushOutbox() {
+    if (!this.dc || this.dc.readyState !== 'open') return;
+    while (
+      this.outbox.length > 0 &&
+      this.dc.bufferedAmount < this.maxBufferedAmount
+    ) {
+      const m = this.outbox.shift()!;
+      if (typeof m === 'string') this.dc.send(m);
+      else if (m instanceof ArrayBuffer) this.dc.send(m);
+      else this.dc.send(m as any);
+    }
+    if (this.outbox.length === 0) {
+      this.events.onDrain?.();
+    }
   }
 }
 

--- a/Toast.tsx
+++ b/Toast.tsx
@@ -1,0 +1,38 @@
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useState,
+} from 'react';
+
+const ToastContext = createContext<(msg: string) => void>(() => {
+  throw new Error('ToastProvider missing');
+});
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<{ id: number; text: string }[]>([]);
+  const add = useCallback((text: string) => {
+    const id = Date.now();
+    setToasts((t) => [...t, { id, text }]);
+    setTimeout(() => {
+      setToasts((t) => t.filter((x) => x.id !== id));
+    }, 3000);
+  }, []);
+  return (
+    <ToastContext.Provider value={add}>
+      {children}
+      <div className="toast-container">
+        {toasts.map((t) => (
+          <div key={t.id} className="toast">
+            {t.text}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  return useContext(ToastContext);
+}

--- a/VoicePanel.tsx
+++ b/VoicePanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { VoiceClient } from './voice_index';
+import { useToast } from './Toast';
 
 export default function VoicePanel() {
   const clientRef = useRef<VoiceClient>();
@@ -7,6 +8,7 @@ export default function VoicePanel() {
   const [status, setStatus] = useState('idle');
   const [partials, setPartials] = useState<string[]>([]);
   const [finals, setFinals] = useState<string[]>([]);
+  const toast = useToast();
 
   useEffect(() => {
     const c = new VoiceClient();
@@ -14,7 +16,7 @@ export default function VoicePanel() {
       if (e.type === 'status') setStatus(e.status);
       if (e.type === 'partial') setPartials((p) => [e.text, ...p].slice(0, 50));
       if (e.type === 'final') setFinals((p) => [e.text, ...p].slice(0, 200));
-      if (e.type === 'error') alert(e.error);
+      if (e.type === 'error') toast(e.error);
     });
     clientRef.current = c;
     return () => {
@@ -37,7 +39,7 @@ export default function VoicePanel() {
         };
         recorderRef.current = rec;
       } catch (err) {
-        alert((err as Error).message);
+        toast((err as Error).message);
         return;
       }
     }

--- a/WebSocketSession.test.ts
+++ b/WebSocketSession.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { WebSocketSession } from './WebSocketSession';
+
+class MockWS {
+  public static OPEN = 1;
+  public readyState = MockWS.OPEN;
+  public bufferedAmount = 0;
+  public sent: any[] = [];
+  onopen?: () => void;
+  onclose?: (e: any) => void;
+  onerror?: (e: any) => void;
+  onmessage?: (e: any) => void;
+  constructor(public url: string) {}
+  send(data: any) {
+    this.sent.push(data);
+  }
+  close() {}
+}
+
+(globalThis as any).WebSocket = MockWS;
+
+describe('WebSocketSession buffering', () => {
+  it('queues when bufferedAmount high and drains on flush', () => {
+    vi.useFakeTimers();
+    const onDrain = vi.fn();
+    const s = new WebSocketSession({
+      url: 'ws://test',
+      onDrain,
+      maxBufferedAmount: 1,
+      heartbeatMs: 10000,
+    });
+    // @ts-ignore access private
+    const ws = (s as any).ws as MockWS;
+    ws.onopen?.();
+    ws.bufferedAmount = 2; // above threshold
+    s.send('a');
+    expect(ws.sent).toHaveLength(0);
+    // @ts-ignore access private
+    expect((s as any).outbox.length).toBe(1);
+    ws.bufferedAmount = 0; // buffer drained
+    vi.advanceTimersByTime(60); // allow flush interval
+    expect(ws.sent).toEqual(['a']);
+    expect(onDrain).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});

--- a/WebSocketSession.ts
+++ b/WebSocketSession.ts
@@ -9,6 +9,8 @@ export type WsOptions = RtcEvents & {
   reconnect?: boolean;
   reconnectMinDelayMs?: number;
   reconnectMaxDelayMs?: number;
+  /** Maximum WebSocket bufferedAmount before queuing */
+  maxBufferedAmount?: number;
 };
 
 export class WebSocketSession {
@@ -25,6 +27,8 @@ export class WebSocketSession {
   private timer: ReturnType<typeof setTimeout> | null = null;
   private abortSignal?: AbortSignal;
   private abortHandler?: () => void;
+  private flushTimer?: ReturnType<typeof setInterval>;
+  private readonly maxBufferedAmount: number;
 
   constructor(opts: WsOptions) {
     this.events = opts;
@@ -34,6 +38,7 @@ export class WebSocketSession {
     this.reconnectDelay = opts.reconnectMinDelayMs ?? 1000;
     this.minDelay = this.reconnectDelay;
     this.maxDelay = opts.reconnectMaxDelayMs ?? 16000;
+    this.maxBufferedAmount = opts.maxBufferedAmount ?? 64 * 1024;
     log('ws', 'WebSocketSession created ' + this.url);
     this.hb = new Heartbeat({
       intervalMs: interval,
@@ -71,13 +76,7 @@ export class WebSocketSession {
       this.hb.start();
       this.events.onOpen?.();
       this.events.onState?.({ ice: 'ws', dc: 'open', rtt: this.hb.rtt });
-      // flush buffered messages
-      const msgs = this.outbox.splice(0);
-      for (const m of msgs) {
-        try {
-          this.send(m);
-        } catch {}
-      }
+      this.flushOutbox();
       this.reconnectDelay = this.minDelay;
     };
     this.ws.onclose = (e) => {
@@ -113,7 +112,12 @@ export class WebSocketSession {
   }
 
   send(data: string | ArrayBuffer | ArrayBufferView) {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+    if (
+      !this.ws ||
+      this.ws.readyState !== WebSocket.OPEN ||
+      this.ws.bufferedAmount > this.maxBufferedAmount ||
+      this.outbox.length > 0
+    ) {
       log('ws', 'queue msg');
       this.outbox.push(data);
       if (this.outbox.length > this.maxOutboxSize) {
@@ -121,6 +125,7 @@ export class WebSocketSession {
         this.outbox.splice(0, drop);
         log('ws', 'drop queued:' + drop);
       }
+      this.ensureFlush();
       return;
     }
     log('ws', 'send:' + (typeof data === 'string' ? data : '[binary]'));
@@ -129,6 +134,9 @@ export class WebSocketSession {
     } else {
       const buf = data instanceof ArrayBuffer ? new Uint8Array(data) : data;
       this.ws.send(buf as any);
+    }
+    if (this.ws.bufferedAmount > this.maxBufferedAmount) {
+      this.ensureFlush();
     }
   }
 
@@ -139,9 +147,44 @@ export class WebSocketSession {
     this.hb.stop();
     this.abortSignal?.removeEventListener('abort', this.abortHandler!);
     this.ws?.close();
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer);
+      this.flushTimer = undefined;
+    }
   }
 
   getStats() {
-    return { rtt: this.hb.rtt };
+    return {
+      rtt: this.hb.rtt,
+      dc: this.ws?.readyState === WebSocket.OPEN ? 'open' : 'closed',
+      ice: 'ws',
+    };
+  }
+
+  private flushOutbox() {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    while (
+      this.outbox.length > 0 &&
+      this.ws.bufferedAmount <= this.maxBufferedAmount
+    ) {
+      const m = this.outbox.shift()!;
+      if (typeof m === 'string') this.ws.send(m);
+      else if (m instanceof ArrayBuffer) this.ws.send(new Uint8Array(m) as any);
+      else this.ws.send(m as any);
+    }
+    if (this.outbox.length === 0) {
+      this.events.onDrain?.();
+      if (this.flushTimer) {
+        clearInterval(this.flushTimer);
+        this.flushTimer = undefined;
+      }
+    } else {
+      this.ensureFlush();
+    }
+  }
+
+  private ensureFlush() {
+    if (this.flushTimer) return;
+    this.flushTimer = setInterval(() => this.flushOutbox(), 50);
   }
 }

--- a/envelope.test.ts
+++ b/envelope.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { generateKeyPair, encryptEnvelope, decryptEnvelope } from './envelope';
+import {
+  generateKeyPair,
+  encryptEnvelope,
+  decryptEnvelope,
+  sign,
+  verify,
+  fingerprintPublicKey,
+} from './envelope';
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -12,13 +19,13 @@ describe('envelope', () => {
 
     const envelope = await encryptEnvelope(
       data.buffer,
-      alice.privateKey,
-      bob.publicKey,
+      alice.ecdh.privateKey,
+      bob.ecdh.publicKey,
     );
     const decrypted = await decryptEnvelope(
       envelope,
-      bob.privateKey,
-      alice.publicKey,
+      bob.ecdh.privateKey,
+      alice.ecdh.publicKey,
     );
 
     expect(decoder.decode(decrypted)).toBe('hello world');
@@ -32,12 +39,12 @@ describe('envelope', () => {
 
     const envelope = await encryptEnvelope(
       data.buffer,
-      alice.privateKey,
-      bob.publicKey,
+      alice.ecdh.privateKey,
+      bob.ecdh.publicKey,
     );
 
     await expect(
-      decryptEnvelope(envelope, charlie.privateKey, alice.publicKey),
+      decryptEnvelope(envelope, charlie.ecdh.privateKey, alice.ecdh.publicKey),
     ).rejects.toThrow();
   });
 
@@ -48,8 +55,8 @@ describe('envelope', () => {
 
     const envelope = await encryptEnvelope(
       data.buffer,
-      alice.privateKey,
-      bob.publicKey,
+      alice.ecdh.privateKey,
+      bob.ecdh.publicKey,
     );
 
     const tampered = new Uint8Array(envelope.ciphertext.slice(0));
@@ -58,9 +65,40 @@ describe('envelope', () => {
     await expect(
       decryptEnvelope(
         { iv: envelope.iv, ciphertext: tampered.buffer },
-        bob.privateKey,
-        alice.publicKey,
+        bob.ecdh.privateKey,
+        alice.ecdh.publicKey,
       ),
     ).rejects.toThrow();
+  });
+
+  it('signs and verifies data', async () => {
+    const alice = await generateKeyPair();
+    const data = encoder.encode('auth-test');
+    const sig = await sign(data.buffer, alice.ecdsa.privateKey);
+    expect(await verify(data.buffer, sig, alice.ecdsa.publicKey)).toBe(true);
+    const tampered = new Uint8Array(sig);
+    tampered[0] ^= 0xff;
+    expect(
+      await verify(data.buffer, tampered.buffer, alice.ecdsa.publicKey),
+    ).toBe(false);
+  });
+
+  it('fails verification with wrong key', async () => {
+    const alice = await generateKeyPair();
+    const bob = await generateKeyPair();
+    const data = encoder.encode('verify fail');
+    const sig = await sign(data.buffer, alice.ecdsa.privateKey);
+    const ok = await verify(data.buffer, sig, bob.ecdsa.publicKey);
+    expect(ok).toBe(false);
+  });
+
+  it('generates stable public key fingerprints', async () => {
+    const alice = await generateKeyPair();
+    const fp1 = await fingerprintPublicKey(alice.ecdh.publicKey);
+    const fp2 = await fingerprintPublicKey(alice.ecdh.publicKey);
+    expect(fp1).toBe(fp2);
+    const bob = await generateKeyPair();
+    const fpBob = await fingerprintPublicKey(bob.ecdh.publicKey);
+    expect(fp1).not.toBe(fpBob);
   });
 });

--- a/file-transfer.test.ts
+++ b/file-transfer.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { MeshRouter, Message, FileChunkPayload } from './Mesh';
+import { encryptEnvelope, decryptEnvelope, generateKeyPair } from './envelope';
+
+async function sendFileThroughMesh(
+  file: File,
+  sender: MeshRouter,
+  receiver: MeshRouter,
+) {
+  const chunkSize = 16 * 1024;
+  const total = Math.ceil(file.size / chunkSize);
+  for (let i = 0; i < total; i++) {
+    const slice = file.slice(
+      i * chunkSize,
+      Math.min(file.size, (i + 1) * chunkSize),
+    );
+    const buf = await slice.arrayBuffer();
+    const payload: FileChunkPayload = {
+      name: file.name,
+      type: file.type,
+      size: file.size,
+      chunk: i,
+      total,
+      data: Array.from(new Uint8Array(buf)),
+    };
+    sender.send({
+      id: crypto.randomUUID(),
+      ttl: 1,
+      type: 'file',
+      payload,
+    } as Message);
+  }
+}
+
+describe('file transfer', () => {
+  it('transfers a small file via mesh', async () => {
+    const a = new MeshRouter('A');
+    const b = new MeshRouter('B');
+    a.connectPeer('B', (m) => b.ingress(m));
+    b.connectPeer('A', (m) => a.ingress(m));
+    const received: number[] = [];
+    b.connectPeer(
+      'INBOX',
+      (m) => {
+        const p = m.payload as FileChunkPayload;
+        received.push(...p.data);
+      },
+      { local: true },
+    );
+
+    const data = new Uint8Array(40000); // 40KB sample
+    data.forEach((_, i) => (data[i] = i % 256));
+    const file = new File([data], 'sample.bin');
+
+    await sendFileThroughMesh(file, a, b);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(received.length).toBe(data.length);
+    expect(new Uint8Array(received)).toEqual(data);
+  });
+
+  it('encrypts and decrypts file chunks', async () => {
+    const a = await generateKeyPair();
+    const b = await generateKeyPair();
+    const buf = new Uint8Array([1, 2, 3, 4]).buffer;
+    const { iv, ciphertext } = await encryptEnvelope(
+      buf,
+      a.ecdh.privateKey,
+      b.ecdh.publicKey,
+    );
+    const plain = await decryptEnvelope(
+      { iv, ciphertext },
+      b.ecdh.privateKey,
+      a.ecdh.publicKey,
+    );
+    expect(new Uint8Array(plain)).toEqual(new Uint8Array(buf));
+  });
+});

--- a/logger.ts
+++ b/logger.ts
@@ -41,7 +41,9 @@ export function downloadLogs() {
 
 export async function uploadLogs(url?: string) {
   const target =
-    url || (import.meta as any).env?.VITE_LOG_UPLOAD_URL || '/logs';
+    url ||
+    (import.meta as any).env?.VITE_LOG_UPLOAD_URL ||
+    '/.netlify/functions/logs';
   try {
     const body = getLogLines().join('\n');
     const res = await fetch(target, {

--- a/main.tsx
+++ b/main.tsx
@@ -5,13 +5,16 @@ import ErrorBoundary from './ErrorBoundary';
 import './styles.css';
 import './sw-register';
 import { enableConsoleCapture } from './logger';
+import { ToastProvider } from './Toast';
 
 enableConsoleCapture();
 
 createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ErrorBoundary>
-      <App />
+      <ToastProvider>
+        <App />
+      </ToastProvider>
     </ErrorBoundary>
   </React.StrictMode>,
 );

--- a/netlify/functions/logs.js
+++ b/netlify/functions/logs.js
@@ -1,0 +1,21 @@
+const fs = require('fs/promises');
+
+// Simple Netlify function that stores POSTed log data on the temp filesystem.
+// In a real deployment this could forward the logs to an external service or
+// email address instead.
+exports.handler = async function (event) {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method Not Allowed' };
+  }
+  try {
+    const body = event.body || '';
+    // Write the body to a temporary file so it can be inspected later.
+    const file = `/tmp/log-${Date.now()}.txt`;
+    await fs.writeFile(file, body, 'utf8');
+    console.log('Stored logs at', file);
+    return { statusCode: 200, body: 'ok' };
+  } catch (err) {
+    console.error('Failed to store logs', err);
+    return { statusCode: 500, body: String(err) };
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sovereign-voice-mesh",
-  "version": "0.0.14",
+  "version": "0.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sovereign-voice-mesh",
-      "version": "0.0.14",
+      "version": "0.0.21",
       "dependencies": {
         "@xenova/transformers": "^2.10.1",
         "jsqr": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sovereign-voice-mesh",
-  "version": "0.0.15",
+  "version": "0.0.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/store.test.ts
+++ b/store.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { generateKeyPair, exportPublicKeyJwk, sign } from './envelope';
+import { verifyAndImportPubKey } from './store';
+
+const encoder = new TextEncoder();
+
+describe('pubkey verification', () => {
+  it('accepts valid signed key', async () => {
+    const kp = await generateKeyPair();
+    const jwk = await exportPublicKeyJwk(kp.ecdh.publicKey);
+    const sigKey = await exportPublicKeyJwk(kp.ecdsa.publicKey);
+    const data = encoder.encode(JSON.stringify(jwk));
+    const sigBuf = await sign(data.buffer, kp.ecdsa.privateKey);
+    const payload = {
+      key: jwk,
+      sig: Array.from(new Uint8Array(sigBuf)),
+      sigKey,
+    };
+    const pub = await verifyAndImportPubKey(payload);
+    expect(pub.type).toBe('public');
+  });
+
+  it('rejects invalid signature', async () => {
+    const kp = await generateKeyPair();
+    const jwk = await exportPublicKeyJwk(kp.ecdh.publicKey);
+    const sigKey = await exportPublicKeyJwk(kp.ecdsa.publicKey);
+    const data = encoder.encode(JSON.stringify(jwk));
+    const sigBuf = await sign(data.buffer, kp.ecdsa.privateKey);
+    const tampered = new Uint8Array(sigBuf);
+    tampered[0] ^= 0xff;
+    const payload = { key: jwk, sig: Array.from(tampered), sigKey };
+    await expect(verifyAndImportPubKey(payload)).rejects.toThrow();
+  });
+  it('rejects unsigned key', async () => {
+    const kp = await generateKeyPair();
+    const jwk = await exportPublicKeyJwk(kp.ecdh.publicKey);
+    await expect(verifyAndImportPubKey({ key: jwk } as any)).rejects.toThrow();
+  });
+
+  it('rejects unsupported key type', async () => {
+    const kp = await generateKeyPair();
+    const jwk = await exportPublicKeyJwk(kp.ecdh.publicKey);
+    // tamper with curve
+    jwk.crv = 'P-384';
+    const sigKey = await exportPublicKeyJwk(kp.ecdsa.publicKey);
+    const data = encoder.encode(JSON.stringify(jwk));
+    const sigBuf = await sign(data.buffer, kp.ecdsa.privateKey);
+    const payload = { key: jwk, sig: Array.from(new Uint8Array(sigBuf)), sigKey };
+    await expect(verifyAndImportPubKey(payload)).rejects.toThrow('unsupported');
+  });
+});

--- a/store.ts
+++ b/store.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { RtcSession } from './RtcSession';
 import { WebSocketSession } from './WebSocketSession';
-import { MeshRouter, Message } from './Mesh';
+import { MeshRouter, Message, IndexedDbSeenAdapter } from './Mesh';
 import { log } from './logger';
 import {
   generateKeyPair,
@@ -10,7 +10,30 @@ import {
   encryptEnvelope,
   decryptEnvelope,
   KeyPair,
+  sign,
+  verify,
+  fingerprintPublicKey,
 } from './envelope';
+
+export async function verifyAndImportPubKey(payload: {
+  key: JsonWebKey;
+  sig?: number[];
+  sigKey?: JsonWebKey;
+}): Promise<CryptoKey> {
+  if (!payload.sig || !payload.sigKey) {
+    throw new Error('missing signature');
+  }
+  const { key } = payload;
+  if (key.kty !== 'EC' || key.crv !== 'P-256') {
+    throw new Error('unsupported key');
+  }
+  const ecdsaPub = await importPublicKeyJwk(payload.sigKey, 'ECDSA');
+  const data = new TextEncoder().encode(JSON.stringify(key));
+  const sigBuf = Uint8Array.from(payload.sig).buffer;
+  const valid = await verify(data.buffer, sigBuf, ecdsaPub);
+  if (!valid) throw new Error('invalid signature');
+  return importPublicKeyJwk(key, 'ECDH');
+}
 
 export interface ChatMessage {
   text: string;
@@ -20,6 +43,8 @@ export interface ChatMessage {
 
 export function useRtcAndMesh() {
   const [useStun, setUseStun] = useState(false);
+  const [stunUrl, setStunUrl] = useState('');
+  const [turnUrl, setTurnUrl] = useState('');
   const [offerJson, setOfferJson] = useState('');
   const [answerJson, setAnswerJson] = useState('');
   const [status, setStatus] = useState('idle');
@@ -27,15 +52,48 @@ export function useRtcAndMesh() {
   const [logLines, setLogLines] = useState<string[]>([]);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [rtt, setRtt] = useState(0);
+  const [rtcStats, setRtcStats] = useState<{
+    rtt?: number;
+    ice?: string;
+    dc?: string;
+  }>({});
+  const [wsStats, setWsStats] = useState<{
+    rtt?: number;
+    ice?: string;
+    dc?: string;
+  }>({});
   const [netInfo, setNetInfo] = useState<{
     type?: string;
     effectiveType?: string;
   }>({});
   const [keys, setKeys] = useState<KeyPair | null>(null);
   const [remotePub, setRemotePub] = useState<CryptoKey | null>(null);
+  const [localFp, setLocalFp] = useState<string>('');
+  const [remoteFp, setRemoteFp] = useState<string>('');
+  const [error, setError] = useState<string | null>(null);
 
   const pending = useRef<string[]>([]);
   const wsRef = useRef<WebSocketSession | null>(null);
+
+  useEffect(() => {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      const s = localStorage.getItem('useStun');
+      if (s) setUseStun(s === 'true');
+      const su = localStorage.getItem('stunUrl');
+      if (su) setStunUrl(su);
+      const tu = localStorage.getItem('turnUrl');
+      if (tu) setTurnUrl(tu);
+    } catch {}
+  }, []);
+  useEffect(() => {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      localStorage.setItem('useStun', String(useStun));
+      localStorage.setItem('stunUrl', stunUrl);
+      localStorage.setItem('turnUrl', turnUrl);
+    } catch {}
+  }, [useStun, stunUrl, turnUrl]);
 
   useEffect(() => {
     const conn = (navigator as any).connection;
@@ -48,9 +106,76 @@ export function useRtcAndMesh() {
     }
   }, []);
 
+  async function loadKeys(): Promise<KeyPair | null> {
+    if (typeof localStorage === 'undefined') return null;
+    try {
+      const raw = localStorage.getItem('keys');
+      if (!raw) return null;
+      const data = JSON.parse(raw);
+      const ecdhPub = await importPublicKeyJwk(data.ecdh.pub, 'ECDH');
+      const ecdhPriv = await crypto.subtle.importKey(
+        'jwk',
+        data.ecdh.priv,
+        { name: 'ECDH', namedCurve: 'P-256' },
+        true,
+        ['deriveKey', 'deriveBits'],
+      );
+      const ecdsaPub = await importPublicKeyJwk(data.ecdsa.pub, 'ECDSA');
+      const ecdsaPriv = await crypto.subtle.importKey(
+        'jwk',
+        data.ecdsa.priv,
+        { name: 'ECDSA', namedCurve: 'P-256' },
+        true,
+        ['sign'],
+      );
+      return {
+        ecdh: { publicKey: ecdhPub, privateKey: ecdhPriv },
+        ecdsa: { publicKey: ecdsaPub, privateKey: ecdsaPriv },
+      } as KeyPair;
+    } catch {
+      return null;
+    }
+  }
+
+  async function saveKeys(k: KeyPair) {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      const ecdhPub = await exportPublicKeyJwk(k.ecdh.publicKey);
+      const ecdhPriv = await crypto.subtle.exportKey('jwk', k.ecdh.privateKey);
+      const ecdsaPub = await exportPublicKeyJwk(k.ecdsa.publicKey);
+      const ecdsaPriv = await crypto.subtle.exportKey(
+        'jwk',
+        k.ecdsa.privateKey,
+      );
+      const payload = {
+        ecdh: { pub: ecdhPub, priv: ecdhPriv },
+        ecdsa: { pub: ecdsaPub, priv: ecdsaPriv },
+      };
+      localStorage.setItem('keys', JSON.stringify(payload));
+    } catch {}
+  }
+
   useEffect(() => {
-    generateKeyPair().then(setKeys);
+    (async () => {
+      const loaded = await loadKeys();
+      if (loaded) {
+        setKeys(loaded);
+      } else {
+        const kp = await generateKeyPair();
+        setKeys(kp);
+        await saveKeys(kp);
+      }
+    })();
   }, []);
+
+  useEffect(() => {
+    if (keys) fingerprintPublicKey(keys.ecdh.publicKey).then(setLocalFp);
+  }, [keys]);
+
+  useEffect(() => {
+    if (remotePub)
+      fingerprintPublicKey(remotePub).then((fp) => setRemoteFp(fp));
+  }, [remotePub]);
 
   useEffect(
     () => () => {
@@ -59,10 +184,17 @@ export function useRtcAndMesh() {
     [],
   );
 
+  const iceServers = useMemo(() => {
+    const servers: RTCIceServer[] = [];
+    if (useStun && stunUrl) servers.push({ urls: stunUrl });
+    if (useStun && turnUrl) servers.push({ urls: turnUrl });
+    return servers;
+  }, [useStun, stunUrl, turnUrl]);
+
   const rtc = useMemo(
     () =>
       new RtcSession({
-        useStun,
+        iceServers,
         heartbeatMs: 5000,
         onOpen: () => {
           push('dc-open');
@@ -81,13 +213,22 @@ export function useRtcAndMesh() {
           if (s.rtt !== undefined) setRtt(s.rtt);
         },
       }),
-    [useStun],
+    [iceServers],
   );
   // Close previous session when options change
   useEffect(() => {
     return () => rtc.close();
   }, [rtc]);
-  const mesh = useMemo(() => new MeshRouter(crypto.randomUUID()), []);
+  const mesh = useMemo(
+    () =>
+      new MeshRouter(
+        crypto.randomUUID(),
+        typeof indexedDB !== 'undefined'
+          ? new IndexedDbSeenAdapter()
+          : undefined,
+      ),
+    [],
+  );
 
   function push(s: string) {
     log('event', s);
@@ -129,13 +270,17 @@ export function useRtcAndMesh() {
 
   async function sendKey() {
     if (!keys) return;
-    const jwk = await exportPublicKeyJwk(keys.publicKey);
+    const jwk = await exportPublicKeyJwk(keys.ecdh.publicKey);
+    const data = new TextEncoder().encode(JSON.stringify(jwk));
+    const sigBuf = await sign(data.buffer, keys.ecdsa.privateKey);
+    const sig = Array.from(new Uint8Array(sigBuf));
+    const sigKey = await exportPublicKeyJwk(keys.ecdsa.publicKey);
     const msg: Message = {
       id: crypto.randomUUID(),
       ttl: 0,
       from: 'LOCAL',
       type: 'pubkey',
-      payload: jwk,
+      payload: { key: jwk, sig, sigKey },
     } as any;
     sendRaw(JSON.stringify(msg));
   }
@@ -158,7 +303,13 @@ export function useRtcAndMesh() {
       wsRef.current.close();
       wsRef.current = null;
     }
-    const url = (import.meta as any).env?.VITE_WS_URL || 'wss://example.com/ws';
+    // Prefer an explicit VITE_WS_URL, but by default point to the same origin
+    // so deployments with a co-located WebSocket server work out of the box.
+    const url =
+      (import.meta as any).env?.VITE_WS_URL ||
+      (location.protocol === 'https:'
+        ? `wss://${location.host}/ws`
+        : `ws://${location.host}/ws`);
     log('ws', 'connecting:' + url);
     const ws = new WebSocketSession({
       url,
@@ -195,6 +346,14 @@ export function useRtcAndMesh() {
     (ws as any).events.onMessage = (rtc as any).events.onMessage;
     wsRef.current = ws;
   }
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setRtcStats(rtc.getStats());
+      setWsStats(wsRef.current?.getStats() || {});
+    }, 1000);
+    return () => clearInterval(id);
+  }, [rtc]);
 
   function addMessage(m: ChatMessage) {
     setMessages((list) => [...list, m]);
@@ -243,9 +402,13 @@ export function useRtcAndMesh() {
         const msg = JSON.parse(raw);
         if (msg.type === 'pubkey') {
           try {
-            const pub = await importPublicKeyJwk(msg.payload);
+            const pub = await verifyAndImportPubKey(msg.payload);
             setRemotePub(pub);
-          } catch {}
+          } catch {
+            setError('invalid remote public key');
+            setStatus('error');
+            push('rx:invalid-pubkey');
+          }
           return;
         }
         if (!isValidMessage(msg)) throw new Error('invalid');
@@ -254,7 +417,7 @@ export function useRtcAndMesh() {
           const ct = new Uint8Array(msg.payload.ciphertext).buffer;
           const data = await decryptEnvelope(
             { iv, ciphertext: ct },
-            keys.privateKey,
+            keys.ecdh.privateKey,
             remotePub,
           );
           msg.payload = JSON.parse(
@@ -330,7 +493,7 @@ export function useRtcAndMesh() {
       throw e;
     }
   }
-  async function sendMesh(payload: any) {
+  async function sendMesh(payload: any, type: string = 'chat') {
     log('event', 'sendMesh:' + JSON.stringify(payload));
     let body = payload;
     let enc = false;
@@ -338,7 +501,7 @@ export function useRtcAndMesh() {
       const data = new TextEncoder().encode(JSON.stringify(payload));
       const { iv, ciphertext } = await encryptEnvelope(
         data.buffer,
-        keys.privateKey,
+        keys.ecdh.privateKey,
         remotePub,
       );
       body = {
@@ -351,16 +514,45 @@ export function useRtcAndMesh() {
       id: crypto.randomUUID(),
       ttl: 8,
       from: 'LOCAL',
-      type: 'chat',
+      type,
       payload: body,
       enc,
-    } as any;
+    };
     sendRaw(JSON.stringify(msg));
+  }
+
+  async function sendFile(
+    file: File,
+    onProgress?: (sent: number, total: number) => void,
+  ) {
+    const chunkSize = 16 * 1024; // 16KB chunks
+    const total = Math.ceil(file.size / chunkSize);
+    for (let i = 0; i < total; i++) {
+      const slice = file.slice(
+        i * chunkSize,
+        Math.min(file.size, (i + 1) * chunkSize),
+      );
+      const buf = await slice.arrayBuffer();
+      const payload = {
+        name: file.name,
+        type: file.type,
+        size: file.size,
+        chunk: i,
+        total,
+        data: Array.from(new Uint8Array(buf)),
+      };
+      await sendMesh(payload, 'file');
+      onProgress?.(i + 1, total);
+    }
   }
 
   return {
     useStun,
     setUseStun,
+    stunUrl,
+    setStunUrl,
+    turnUrl,
+    setTurnUrl,
     createOffer,
     acceptOfferAndCreateAnswer,
     acceptAnswer,
@@ -368,12 +560,20 @@ export function useRtcAndMesh() {
     answerJson,
     status,
     sendMesh,
+    sendFile,
     lastMsg,
     log: logLines,
     messages,
     addMessage,
     clearMessages,
     rtt,
+    rtcStats,
+    wsStats,
     netInfo,
+    startWsFallback,
+    localFingerprint: localFp,
+    remoteFingerprint: remoteFp,
+    error,
+    clearError: () => setError(null),
   };
 }

--- a/styles.css
+++ b/styles.css
@@ -74,3 +74,21 @@ hr {
   border-top: 1px solid #1f3242;
   margin: 16px 0;
 }
+
+.toast-container {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 1000;
+}
+
+.toast {
+  background: #1f3242;
+  color: var(--fg);
+  padding: 8px 12px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+}

--- a/sw-register.ts
+++ b/sw-register.ts
@@ -1,6 +1,10 @@
 // Registers the basic SW for offline support.
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.ts').catch(console.error);
+    // Register the compiled service worker rather than the TypeScript source.
+    // During development Vite serves the TypeScript module directly, but after
+    // build the worker lives at /sw.js. Using the compiled path ensures the
+    // worker actually registers in production builds.
+    navigator.serviceWorker.register('/sw.js').catch(console.error);
   });
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,5 +18,8 @@ export default defineConfig({
     'import.meta.env.VITE_APP_VERSION': JSON.stringify(
       process.env.npm_package_version,
     ),
+    'import.meta.env.VITE_WS_URL': JSON.stringify(
+      process.env.VITE_WS_URL || '',
+    ),
   },
 });


### PR DESCRIPTION
## Summary
- add ECDSA sign/verify helpers and fingerprinting utilities for public keys
- sign outbound public keys and verify remote key signatures in the store, rejecting invalid keys
- surface remote key signature failures in pairing interfaces via toast notifications
- resolve merge conflicts with main and clean up netlify log handler

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b67b98c33883219221046eee536335