### PR TITLE
Add tests for chat formatting and service worker registration

### DIFF
--- a/Chat.tsx
+++ b/Chat.tsx
@@ -2,14 +2,14 @@ import { useRtcAndMesh } from './store';
 import { useState } from 'react';
 import { useToast } from './Toast';
 
-function escapeHtml(text: string) {
+export function escapeHtml(text: string) {
   return text
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
 }
 
-function formatMessage(text: string) {
+export function formatMessage(text: string) {
   let html = escapeHtml(text);
   html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
   html = html.replace(/\*(.+?)\*/g, '<em>$1</em>');

--- a/chat.test.ts
+++ b/chat.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { formatMessage } from './Chat';
+
+describe('Chat message formatting', () => {
+  it('escapes HTML, formats markdown, and links URLs', () => {
+    const input = '**bold** *italic* `code` <b>html</b>\nhttps://example.com';
+    const output = formatMessage(input);
+    expect(output).toContain('<strong>bold</strong>');
+    expect(output).toContain('<em>italic</em>');
+    expect(output).toContain('<code>code</code>');
+    expect(output).toContain('&lt;b&gt;html&lt;/b&gt;');
+    expect(output).toContain(
+      '<a href="https://example.com" target="_blank" rel="noopener">https://example.com</a>',
+    );
+    expect(output).toContain('<br/>');
+  });
+});

--- a/sw-register.test.ts
+++ b/sw-register.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest';
+
+describe('service worker registration', () => {
+  it('registers the compiled service worker on window load', async () => {
+    const register = vi.fn(() => Promise.resolve());
+    const listeners: Record<string, () => void> = {};
+    (globalThis as any).navigator = { serviceWorker: { register } };
+    (globalThis as any).window = {
+      addEventListener: (event: string, handler: () => void) => {
+        listeners[event] = handler;
+      },
+    };
+
+    await import('./sw-register');
+    await listeners['load']();
+
+    expect(register).toHaveBeenCalledWith('/sw.js');
+  });
+});


### PR DESCRIPTION
## Summary
- Export chat formatting helpers for reuse
- Add unit test verifying chat message formatting and link handling
- Add unit test to ensure service worker registers compiled script on load

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b78f791c10832192df955be3f8b696